### PR TITLE
Add OP_PUT stack opcode

### DIFF
--- a/pkg/arkade/opcode.go
+++ b/pkg/arkade/opcode.go
@@ -233,7 +233,7 @@ const (
 	OP_NOP9                = 0xb8 // 184
 	OP_NOP10               = 0xb9 // 185
 	OP_CHECKSIGADD         = 0xba // 186
-	OP_UNKNOWN187          = 0xbb // 187
+	OP_PUT                 = 0xbb // 187
 	OP_UNKNOWN188          = 0xbc // 188
 	OP_UNKNOWN189          = 0xbd // 189
 	OP_UNKNOWN190          = 0xbe // 190
@@ -533,8 +533,9 @@ var opcodeArray = [256]opcode{
 	OP_NOP9:               {OP_NOP9, "OP_NOP9", 1, opcodeNop},
 	OP_NOP10:              {OP_NOP10, "OP_NOP10", 1, opcodeNop},
 
+	OP_PUT: {OP_PUT, "OP_PUT", 1, opcodePut},
+
 	// Undefined opcodes.
-	OP_UNKNOWN187: {OP_UNKNOWN187, "OP_UNKNOWN187", 1, opcodeInvalid},
 	OP_UNKNOWN188: {OP_UNKNOWN188, "OP_UNKNOWN188", 1, opcodeInvalid},
 	OP_UNKNOWN189: {OP_UNKNOWN189, "OP_UNKNOWN189", 1, opcodeInvalid},
 	OP_UNKNOWN190: {OP_UNKNOWN190, "OP_UNKNOWN190", 1, opcodeInvalid},
@@ -1172,6 +1173,26 @@ func opcodePick(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	return vm.dstack.PickN(val.Int32())
+}
+
+// opcodePut treats the top item on the data stack as an integer and replaces
+// the item that number of items back with the value beneath it.
+//
+// Stack transformation: [xn ... x2 x1 x0 value n] -> [value ... x2 x1 x0]
+// Example with n=0: [x2 x1 x0 value 0] -> [x2 x1 value]
+// Example with n=2: [x2 x1 x0 value 2] -> [value x1 x0]
+func opcodePut(op *opcode, data []byte, vm *Engine) error {
+	val, err := vm.dstack.PopInt()
+	if err != nil {
+		return err
+	}
+
+	so, err := vm.dstack.PopByteArray()
+	if err != nil {
+		return err
+	}
+
+	return vm.dstack.PutN(val.Int32(), so)
 }
 
 // opcodeRoll treats the top item on the data stack as an integer and moves

--- a/pkg/arkade/opcode_fuzz_test.go
+++ b/pkg/arkade/opcode_fuzz_test.go
@@ -72,6 +72,14 @@ func (defaultCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzC
 	return c
 }
 
+type putCaseBuilder struct{}
+
+func (putCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcodeFuzzCase {
+	c := defaultCaseBuilder{}.Build(data, world)
+	c.stackPushes = [][]byte{saltedBytes(data, 0x70), saltedBytes(data, 0x71), nil}
+	return c
+}
+
 type indexCaseBuilder struct {
 	isOut bool
 }
@@ -364,6 +372,7 @@ func (b assetLookupCaseBuilder) Build(data []byte, world *opcodeFuzzWorld) opcod
 }
 
 var fuzzCaseBuilders = [256]fuzzCaseBuilder{
+	OP_PUT:                           putCaseBuilder{},
 	OP_INSPECTINPUTOUTPOINT:          indexCaseBuilder{},
 	OP_INSPECTINPUTSEQUENCE:          indexCaseBuilder{},
 	OP_INSPECTINPUTSCRIPTPUBKEY:      indexCaseBuilder{},

--- a/pkg/arkade/opcode_test.go
+++ b/pkg/arkade/opcode_test.go
@@ -201,6 +201,7 @@ var opcodeSpecs = [256]*opcodeSpec{
 	OP_NIP:                stackOpSpec(OP_NIP),
 	OP_OVER:               stackOpSpec(OP_OVER),
 	OP_PICK:               pickSpec(),
+	OP_PUT:                putSpec(),
 	OP_ROLL:               rollSpec(),
 	OP_ROT:                stackOpSpec(OP_ROT),
 	OP_SWAP:               stackOpSpec(OP_SWAP),
@@ -339,7 +340,6 @@ var opcodeSpecs = [256]*opcodeSpec{
 	OP_VERNOTIF:                      reservedSpec(OP_VERNOTIF),
 	OP_RESERVED1:                     reservedSpec(OP_RESERVED1),
 	OP_RESERVED2:                     reservedSpec(OP_RESERVED2),
-	OP_UNKNOWN187:                    invalidSpec(OP_UNKNOWN187),
 	OP_UNKNOWN188:                    invalidSpec(OP_UNKNOWN188),
 	OP_UNKNOWN189:                    invalidSpec(OP_UNKNOWN189),
 	OP_UNKNOWN190:                    invalidSpec(OP_UNKNOWN190),
@@ -1191,6 +1191,77 @@ func pickSpec() *opcodeSpec {
 			{
 				name:          "out_of_range",
 				inputStack:    [][]byte{{0x01}, scriptNum(2).Bytes()},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},
+		},
+	}
+}
+
+func putSpec() *opcodeSpec {
+	return &opcodeSpec{
+		opcode: OP_PUT,
+		checkProperties: func(t *testing.T, c opcodeCheckContext) {
+			t.Helper()
+			require.Equal(t, c.before.GetAltStack(), c.after.GetAltStack())
+			require.Equal(t, c.before.condStack, c.after.condStack)
+
+			beforeStack := c.before.GetStack()
+			afterStack := c.after.GetStack()
+			if c.execErr != nil {
+				requireScriptErrorCodeIn(t, c.execErr,
+					txscript.ErrInvalidStackOperation,
+					txscript.ErrNumberTooBig,
+					txscript.ErrMinimalData,
+				)
+				require.GreaterOrEqual(t, len(afterStack), len(beforeStack)-2)
+				require.LessOrEqual(t, len(afterStack), len(beforeStack))
+				return
+			}
+
+			require.Equal(t, len(beforeStack)-2, len(afterStack))
+			n, err := MakeScriptNum(beforeStack[len(beforeStack)-1], true, maxScriptNumLen)
+			require.NoError(t, err)
+			expected := slices.Clone(beforeStack[:len(beforeStack)-2])
+			expected[len(expected)-int(n)-1] = beforeStack[len(beforeStack)-2]
+			require.Equal(t, expected, afterStack)
+		},
+		validVectors: []opcodeVector{
+			{
+				name:          "put_0",
+				inputStack:    [][]byte{{0x01}, {0x02}, {0x09}, nil},
+				expectedStack: [][]byte{{0x01}, {0x09}},
+			},
+			{
+				name:          "put_1",
+				inputStack:    [][]byte{{0x01}, {0x02}, {0x09}, scriptNum(1).Bytes()},
+				expectedStack: [][]byte{{0x09}, {0x02}},
+			},
+			{
+				name:          "put_2",
+				inputStack:    [][]byte{{0x01}, {0x02}, {0x03}, {0x09}, scriptNum(2).Bytes()},
+				expectedStack: [][]byte{{0x09}, {0x02}, {0x03}},
+			},
+			{
+				name:          "put_empty",
+				inputStack:    [][]byte{{0x01}, {0x02}, nil, nil},
+				expectedStack: [][]byte{{0x01}, nil},
+			},
+		},
+		invalidVectors: []opcodeVector{
+			{
+				name:          "negative_index",
+				inputStack:    [][]byte{{0x01}, {0x09}, scriptNum(-1).Bytes()},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:          "out_of_range",
+				inputStack:    [][]byte{{0x01}, {0x09}, scriptNum(1).Bytes()},
+				expectedError: txscript.ErrInvalidStackOperation,
+			},
+			{
+				name:          "missing_target",
+				inputStack:    [][]byte{{0x09}, nil},
 				expectedError: txscript.ErrInvalidStackOperation,
 			},
 			{name: "underflow", expectedError: txscript.ErrInvalidStackOperation},

--- a/pkg/arkade/stack.go
+++ b/pkg/arkade/stack.go
@@ -364,6 +364,21 @@ func (s *stack) PickN(n int32) error {
 	return nil
 }
 
+// PutN replaces the item N items back in the stack.
+//
+// Stack transformation:
+// PutN(0, x): [x1 x2 x3] -> [x1 x2 x]
+// PutN(1, x): [x1 x2 x3] -> [x1 x x3]
+// PutN(2, x): [x1 x2 x3] -> [x x2 x3]
+func (s *stack) PutN(n int32, so []byte) error {
+	if _, err := s.PeekByteArray(n); err != nil {
+		return err
+	}
+	s.stk[len(s.stk)-int(n)-1] = so
+
+	return nil
+}
+
 // RollN moves the item N items back in the stack to the top.
 //
 // Stack transformation:

--- a/pkg/arkade/stack_test.go
+++ b/pkg/arkade/stack_test.go
@@ -774,6 +774,33 @@ func TestStack(t *testing.T) {
 			nil,
 		},
 		{
+			"Put0",
+			[][]byte{{1}, {2}, {3}, {4}},
+			func(s *stack) error {
+				return s.PutN(0, []byte{9})
+			},
+			nil,
+			[][]byte{{1}, {2}, {3}, {9}},
+		},
+		{
+			"Put2",
+			[][]byte{{1}, {2}, {3}, {4}},
+			func(s *stack) error {
+				return s.PutN(2, []byte{9})
+			},
+			nil,
+			[][]byte{{1}, {9}, {3}, {4}},
+		},
+		{
+			"Put too little",
+			[][]byte{{1}},
+			func(s *stack) error {
+				return s.PutN(1, []byte{9})
+			},
+			scriptError(txscript.ErrInvalidStackOperation, ""),
+			nil,
+		},
+		{
 			"Roll1",
 			[][]byte{{1}, {2}, {3}, {4}},
 			func(s *stack) error {


### PR DESCRIPTION
## Summary

- add `OP_PUT` at `0xbb` (187), replacing the previously undefined opcode slot
- replace a stack item at a runtime-selected depth without changing the surrounding stack shape
- cover top, middle, bottom, empty-value, invalid-depth, disassembly, and fuzzed serialized execution paths

## Semantics

`OP_PUT` pops `depth`, pops `value`, then replaces the item at `depth` measured in the remaining stack:

```text
[..., x_n, ..., x_1, x_0, value, n] OP_PUT
→
[..., value, ..., x_1, x_0]
```

The successful stack effect is always `-2`. `depth` uses the same minimally encoded four-byte script-number rules as `OP_PICK` and `OP_ROLL`; negative and out-of-range depths fail with `ErrInvalidStackOperation`.

## Arkade language impact

The compiler lives in a separate repository, so its lowering is a follow-up after this VM opcode lands. These examples were compiled with the current compiler to measure the opportunity.

### Simple mutable variable

```ark
contract Counter() {
    function spend(int amount) {
        let total = amount;
        total = total + 1;
        require(total > amount);
    }
}
```

Today the replacement tail is:

```text
OP_1 OP_ROLL OP_DROP
```

With `OP_PUT` it becomes:

```text
OP_0 OP_PUT
```

The complete covenant drops from 18 to 17 assembly tokens. The small saving is the important base case: every scalar assignment becomes constant-size and no longer needs special stack restoration.

### Deep assignment

```ark
contract DeepAssignment() {
    function spend(int amount) {
        int[16] balances = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
        balances[15] = amount;
        require(balances[15] == amount);
    }
}
```

The current assignment emits 48 tokens: the value expression, `OP_16 OP_ROLL OP_DROP`, 15 `OP_SWAP`s, 14 `OP_TOALTSTACK`s, and 14 `OP_FROMALTSTACK`s. With `OP_PUT`, the same assignment is four tokens:

```text
OP_16 OP_PICK OP_15 OP_PUT
```

That reduces the full covenant from 88 to 44 assembly tokens. The saving grows linearly with assignment depth while `OP_PUT` remains constant-size.

Runtime-indexed array assignment will additionally retain the compiler's `0 <= index < array.length` checks so an index cannot overwrite an adjacent binding.

## Validation

- `make test`
- `golangci-lint run --new-from-rev=HEAD` from `pkg/arkade`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `OP_PUT` script operation.
  - Scripts can now replace a value at a specified stack position without changing the stack depth.
  - Supports indexed updates for both top-of-stack and deeper stack items.

- **Bug Fixes**
  - Invalid indices, missing stack items, and insufficient stack depth now return appropriate script errors instead of performing an update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->