### PR TITLE
test: dust-free transfer covenant

### DIFF
--- a/test/covenant/covenant.go
+++ b/test/covenant/covenant.go
@@ -1,0 +1,269 @@
+// Package covenant builds the arkade covenants for dust-free asset and
+// sub-dust bitcoin transfers, where a service operator fronts the dust unit and
+// the covenant guarantees its repayment.
+//
+// See docs/superpowers/specs/2026-09-07-dust-free-transfer-covenant-design.md.
+package covenant
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/arkade-os/emulator/pkg/arkade"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+)
+
+// Leaf positions in the taptree. Order fixes the merkle root, so it is part of
+// the address and must not be reordered.
+const (
+	LeafRecycle = iota
+	LeafPurchase
+	LeafRefundSender
+	LeafRecovery
+)
+
+// Params are the values committed at lockup. Together they determine the
+// covenant scripts, hence the emulator tweak, hence the taproot output key.
+type Params struct {
+	ReceiverKey *btcec.PublicKey
+	SenderKey   *btcec.PublicKey
+	OperatorKey *btcec.PublicKey
+
+	// Dust is the covenant output's value, equal to the Arkade Service's dust
+	// setting. Topup is the operator's advance; the sender contributes the
+	// remainder, which is zero for a pure-asset payment.
+	Dust  int64
+	Topup int64
+
+	// AssetID is nil for the bitcoin variant. The asset introspection opcodes
+	// raise "no asset packet" rather than returning zero when a transaction
+	// carries no asset packet, so the two variants cannot share one script.
+	AssetID *asset.AssetId
+
+	Locktime arklib.AbsoluteLocktime
+}
+
+func (p Params) Validate(vtxoMinAmount int64) error {
+	switch {
+	case p.ReceiverKey == nil || p.SenderKey == nil || p.OperatorKey == nil:
+		return fmt.Errorf("covenant: receiver, sender and operator keys are required")
+	case p.Dust <= 0:
+		return fmt.Errorf("covenant: dust must be positive, got %d", p.Dust)
+	case vtxoMinAmount <= 0:
+		return fmt.Errorf("covenant: vtxoMinAmount must be positive, got %d", vtxoMinAmount)
+	case p.Topup < vtxoMinAmount || p.Topup > p.Dust:
+		return fmt.Errorf(
+			"covenant: topup %d outside [%d, %d]", p.Topup, vtxoMinAmount, p.Dust,
+		)
+	}
+	return nil
+}
+
+// RefundTopup is what the operator recovers on the refund leaves. It falls below
+// Topup only when the operator funded the whole dust unit, where one
+// vtxoMinAmount must stay behind to host the sender's returned asset: an asset
+// cannot occupy an output on its own.
+func (p Params) RefundTopup(vtxoMinAmount int64) int64 {
+	if capped := p.Dust - vtxoMinAmount; p.Topup > capped {
+		return capped
+	}
+	return p.Topup
+}
+
+// PayoutPkScript is the scriptPubKey a covenant-pinned payout must use: P2TR at
+// or above dust, sub-dust OP_RETURN below it. It must agree with pinOutput, or
+// the covenant rejects its own intended spend.
+func PayoutPkScript(key *btcec.PublicKey, value, dust int64) ([]byte, error) {
+	if value >= dust {
+		return script.P2TRScript(key)
+	}
+	return script.SubDustScript(key)
+}
+
+// pinOutput binds an output to a key. pushScriptPubKey reports a witness program
+// as (program, version) but anything else as (sha256(script), -1), so a
+// below-dust output must be pinned in its sub-dust OP_RETURN form.
+func pinOutput(
+	b *txscript.ScriptBuilder, vout int64, key *btcec.PublicKey, value, dust int64,
+) error {
+	b.AddInt64(vout).AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY)
+	if value >= dust {
+		b.AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
+			AddData(schnorr.SerializePubKey(key)).AddOp(arkade.OP_EQUALVERIFY)
+		return nil
+	}
+	subDust, err := script.SubDustScript(key)
+	if err != nil {
+		return err
+	}
+	h := sha256.Sum256(subDust)
+	b.AddInt64(-1).AddOp(arkade.OP_EQUALVERIFY).AddData(h[:]).AddOp(arkade.OP_EQUALVERIFY)
+	return nil
+}
+
+// appendAssetLookup leaves the asset amount on the stack, dropping the found
+// flag: a miss pushes (0, 0), which is exactly "holds none of this asset".
+// id.Txid must be in chainhash internal byte order, never the reversed display
+// hex -- the wrong order yields a covenant that silently never matches.
+func appendAssetLookup(b *txscript.ScriptBuilder, idx int64, id *asset.AssetId, output bool) {
+	op := byte(arkade.OP_INSPECTINASSETLOOKUP)
+	if output {
+		op = byte(arkade.OP_INSPECTOUTASSETLOOKUP)
+	}
+	b.AddInt64(idx).AddData(id.Txid[:]).AddInt64(int64(id.Index)).
+		AddOp(op).AddOp(arkade.OP_DROP)
+}
+
+func finish(b *txscript.ScriptBuilder, hasAsset bool) ([]byte, error) {
+	if !hasAsset {
+		b.AddOp(arkade.OP_1)
+	}
+	return b.Script()
+}
+
+// BuildRecycle gates the receiver merging the covenant into an account they
+// already own, repaying the operator's advance in sats.
+//
+//	in[0] covenant, in[1] receiver account
+//	out[0] operator repaid Topup, out[1] receiver's merged account
+//
+// Output value is enforced as a sum over both inputs rather than as a constant,
+// so the receiver's prior balance is irrelevant.
+func BuildRecycle(p Params) ([]byte, error) {
+	b := txscript.NewScriptBuilder().
+		AddOp(arkade.OP_PUSHCURRENTINPUTINDEX).AddInt64(0).AddOp(arkade.OP_EQUALVERIFY).
+		AddOp(arkade.OP_INSPECTNUMINPUTS).AddInt64(2).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(1).AddOp(arkade.OP_INSPECTINPUTSCRIPTPUBKEY).
+		AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
+		AddData(schnorr.SerializePubKey(p.ReceiverKey)).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddInt64(p.Topup).AddOp(arkade.OP_EQUALVERIFY)
+
+	if err := pinOutput(b, 0, p.OperatorKey, p.Topup, p.Dust); err != nil {
+		return nil, err
+	}
+
+	b.AddInt64(1).AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
+		AddData(schnorr.SerializePubKey(p.ReceiverKey)).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(1).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddInt64(0).AddOp(arkade.OP_INSPECTINPUTVALUE).
+		AddInt64(1).AddOp(arkade.OP_INSPECTINPUTVALUE).AddOp(arkade.OP_ADD).
+		AddInt64(p.Topup).AddOp(arkade.OP_SUB).
+		AddOp(arkade.OP_EQUALVERIFY)
+
+	if p.AssetID != nil {
+		appendAssetLookup(b, 1, p.AssetID, true)
+		appendAssetLookup(b, 0, p.AssetID, false)
+		appendAssetLookup(b, 1, p.AssetID, false)
+		b.AddOp(arkade.OP_ADD).AddOp(arkade.OP_EQUAL)
+	}
+	return finish(b, p.AssetID != nil)
+}
+
+// BuildPurchase pays the whole covenant to the receiver. The operator recovers
+// nothing, having been compensated at lockup.
+func BuildPurchase(p Params) ([]byte, error) {
+	b := txscript.NewScriptBuilder().
+		AddOp(arkade.OP_PUSHCURRENTINPUTINDEX).AddInt64(0).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
+		AddData(schnorr.SerializePubKey(p.ReceiverKey)).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddInt64(0).AddOp(arkade.OP_INSPECTINPUTVALUE).AddOp(arkade.OP_EQUALVERIFY)
+
+	if p.AssetID != nil {
+		appendAssetLookup(b, 0, p.AssetID, true)
+		appendAssetLookup(b, 0, p.AssetID, false)
+		b.AddOp(arkade.OP_EQUAL)
+	}
+	return finish(b, p.AssetID != nil)
+}
+
+// BuildRefund returns the payload to the sender and repays the operator. Shared
+// by the sender-signed refund leaf and the timelocked recovery leaf. The sender
+// receives a sub-dust receipt, acceptable because the sender demonstrably owns a
+// funded account and can merge it later; it would not be acceptable for the
+// receiver, which is why no claim leaf pays sub-dust.
+func BuildRefund(p Params, vtxoMinAmount int64) ([]byte, error) {
+	topup := p.RefundTopup(vtxoMinAmount)
+	b := txscript.NewScriptBuilder().
+		AddOp(arkade.OP_PUSHCURRENTINPUTINDEX).AddInt64(0).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddInt64(topup).AddOp(arkade.OP_EQUALVERIFY)
+
+	if err := pinOutput(b, 0, p.OperatorKey, topup, p.Dust); err != nil {
+		return nil, err
+	}
+
+	b.AddInt64(1).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddInt64(p.Dust - topup).AddOp(arkade.OP_EQUALVERIFY)
+
+	if err := pinOutput(b, 1, p.SenderKey, p.Dust-topup, p.Dust); err != nil {
+		return nil, err
+	}
+
+	if p.AssetID != nil {
+		appendAssetLookup(b, 1, p.AssetID, true)
+		appendAssetLookup(b, 0, p.AssetID, false)
+		b.AddOp(arkade.OP_EQUAL)
+	}
+	return finish(b, p.AssetID != nil)
+}
+
+// Scripts are the three covenants a contract commits to.
+type Scripts struct {
+	Recycle  []byte
+	Purchase []byte
+	Refund   []byte
+}
+
+func Build(p Params, vtxoMinAmount int64) (Scripts, error) {
+	if err := p.Validate(vtxoMinAmount); err != nil {
+		return Scripts{}, err
+	}
+	recycle, err := BuildRecycle(p)
+	if err != nil {
+		return Scripts{}, err
+	}
+	purchase, err := BuildPurchase(p)
+	if err != nil {
+		return Scripts{}, err
+	}
+	refund, err := BuildRefund(p, vtxoMinAmount)
+	if err != nil {
+		return Scripts{}, err
+	}
+	return Scripts{Recycle: recycle, Purchase: purchase, Refund: refund}, nil
+}
+
+// VtxoScript assembles the four-leaf taptree. Every leaf but LeafRefundSender is
+// arkade-only, so anyone able to construct a satisfying transaction may spend it
+// -- that is what lets the receiver stay offline at payment time.
+func VtxoScript(
+	server, emulator, sender *btcec.PublicKey, p Params, s Scripts,
+) script.TapscriptsVtxoScript {
+	tweak := func(b []byte) *btcec.PublicKey {
+		return arkade.ComputeArkadeScriptPublicKey(emulator, arkade.ArkadeScriptHash(b))
+	}
+	return script.TapscriptsVtxoScript{
+		Closures: []script.Closure{
+			&script.MultisigClosure{PubKeys: []*btcec.PublicKey{server, tweak(s.Recycle)}},
+			&script.MultisigClosure{PubKeys: []*btcec.PublicKey{server, tweak(s.Purchase)}},
+			&script.MultisigClosure{
+				PubKeys: []*btcec.PublicKey{server, sender, tweak(s.Refund)},
+			},
+			&script.CLTVMultisigClosure{
+				MultisigClosure: script.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{server, tweak(s.Refund)},
+				},
+				Locktime: p.Locktime,
+			},
+		},
+	}
+}

--- a/test/covenant/covenant.go
+++ b/test/covenant/covenant.go
@@ -106,17 +106,30 @@ func pinOutput(
 	return nil
 }
 
-// appendAssetLookup leaves the asset amount on the stack, dropping the found
-// flag: a miss pushes (0, 0), which is exactly "holds none of this asset".
-// id.Txid must be in chainhash internal byte order, never the reversed display
-// hex -- the wrong order yields a covenant that silently never matches.
-func appendAssetLookup(b *txscript.ScriptBuilder, idx int64, id *asset.AssetId, output bool) {
+// appendAssetLookup leaves the asset amount on the stack and consumes the found
+// flag. id.Txid must be in chainhash internal byte order, never the reversed
+// display hex.
+//
+// required decides how the flag is consumed, and the distinction is load-bearing.
+// A miss pushes (0, 0). Dropping the flag everywhere makes a wrong AssetID --
+// whether from a byte-order slip or a deliberate substitution -- miss on every
+// read, degenerating the sum to 0 == 0 + 0 so the covenant passes with the asset
+// constraint silently unenforced. OP_VERIFY where the asset must exist turns
+// that quiet failure into a loud one. Only the receiver's prior balance may
+// legitimately be absent, so only that lookup drops.
+func appendAssetLookup(
+	b *txscript.ScriptBuilder, idx int64, id *asset.AssetId, output, required bool,
+) {
 	op := byte(arkade.OP_INSPECTINASSETLOOKUP)
 	if output {
 		op = byte(arkade.OP_INSPECTOUTASSETLOOKUP)
 	}
-	b.AddInt64(idx).AddData(id.Txid[:]).AddInt64(int64(id.Index)).
-		AddOp(op).AddOp(arkade.OP_DROP)
+	b.AddInt64(idx).AddData(id.Txid[:]).AddInt64(int64(id.Index)).AddOp(op)
+	if required {
+		b.AddOp(arkade.OP_VERIFY)
+		return
+	}
+	b.AddOp(arkade.OP_DROP)
 }
 
 func finish(b *txscript.ScriptBuilder, hasAsset bool) ([]byte, error) {
@@ -158,9 +171,9 @@ func BuildRecycle(p Params) ([]byte, error) {
 		AddOp(arkade.OP_EQUALVERIFY)
 
 	if p.AssetID != nil {
-		appendAssetLookup(b, 1, p.AssetID, true)
-		appendAssetLookup(b, 0, p.AssetID, false)
-		appendAssetLookup(b, 1, p.AssetID, false)
+		appendAssetLookup(b, 1, p.AssetID, true, true)
+		appendAssetLookup(b, 0, p.AssetID, false, true)
+		appendAssetLookup(b, 1, p.AssetID, false, false)
 		b.AddOp(arkade.OP_ADD).AddOp(arkade.OP_EQUAL)
 	}
 	return finish(b, p.AssetID != nil)
@@ -178,8 +191,8 @@ func BuildPurchase(p Params) ([]byte, error) {
 		AddInt64(0).AddOp(arkade.OP_INSPECTINPUTVALUE).AddOp(arkade.OP_EQUALVERIFY)
 
 	if p.AssetID != nil {
-		appendAssetLookup(b, 0, p.AssetID, true)
-		appendAssetLookup(b, 0, p.AssetID, false)
+		appendAssetLookup(b, 0, p.AssetID, true, true)
+		appendAssetLookup(b, 0, p.AssetID, false, true)
 		b.AddOp(arkade.OP_EQUAL)
 	}
 	return finish(b, p.AssetID != nil)
@@ -209,8 +222,8 @@ func BuildRefund(p Params, vtxoMinAmount int64) ([]byte, error) {
 	}
 
 	if p.AssetID != nil {
-		appendAssetLookup(b, 1, p.AssetID, true)
-		appendAssetLookup(b, 0, p.AssetID, false)
+		appendAssetLookup(b, 1, p.AssetID, true, true)
+		appendAssetLookup(b, 0, p.AssetID, false, true)
 		b.AddOp(arkade.OP_EQUAL)
 	}
 	return finish(b, p.AssetID != nil)

--- a/test/covenant/covenant.go
+++ b/test/covenant/covenant.go
@@ -186,6 +186,11 @@ func BuildRecycle(p Params) ([]byte, error) {
 
 // BuildPurchase pays the whole covenant to the receiver. The operator recovers
 // nothing, having been compensated at lockup.
+//
+// Unlike BuildRecycle this deliberately does not pin the input count. It reads
+// only in[0], and out[0] is tied to in[0]'s value and asset amount, so an extra
+// input cannot divert the covenant -- whatever a spender adds flows to their own
+// outputs. Recycle needs the guard because it reads a second input.
 func BuildPurchase(p Params) ([]byte, error) {
 	b := txscript.NewScriptBuilder().
 		AddOp(arkade.OP_PUSHCURRENTINPUTINDEX).AddInt64(0).AddOp(arkade.OP_EQUALVERIFY).

--- a/test/covenant/covenant.go
+++ b/test/covenant/covenant.go
@@ -60,6 +60,11 @@ func (p Params) Validate(vtxoMinAmount int64) error {
 		return fmt.Errorf(
 			"covenant: topup %d outside [%d, %d]", p.Topup, vtxoMinAmount, p.Dust,
 		)
+	case p.Locktime == 0:
+		// A zero absolute locktime is always satisfied, which would make the
+		// recovery leaf spendable the moment the covenant is funded and collapse
+		// the timeout the operator's exposure is bounded by.
+		return fmt.Errorf("covenant: locktime must be non-zero")
 	}
 	return nil
 }

--- a/test/covenant/covenant.go
+++ b/test/covenant/covenant.go
@@ -60,6 +60,14 @@ func (p Params) Validate(vtxoMinAmount int64) error {
 		return fmt.Errorf(
 			"covenant: topup %d outside [%d, %d]", p.Topup, vtxoMinAmount, p.Dust,
 		)
+	case p.ReceiverKey.IsEqual(p.OperatorKey) ||
+		p.ReceiverKey.IsEqual(p.SenderKey) ||
+		p.SenderKey.IsEqual(p.OperatorKey):
+		// Reusing a key collapses a role. Receiver == operator is the dangerous
+		// one: the operator could satisfy recycle while paying the top-up
+		// repayment to itself, collecting both sides of the trade. No signature
+		// check catches this, because each role's key is legitimately its own.
+		return fmt.Errorf("covenant: receiver, sender and operator keys must be distinct")
 	case p.Locktime == 0:
 		// A zero absolute locktime is always satisfied, which would make the
 		// recovery leaf spendable the moment the covenant is funded and collapse

--- a/test/covenant/covenant_test.go
+++ b/test/covenant/covenant_test.go
@@ -506,6 +506,32 @@ func TestBitcoinVariant(t *testing.T) {
 		c.outputs[1].Value++
 		requireRejected(t, run(t, s.Recycle, c))
 	})
+
+	// Purchase in bitcoin mode terminates via the asset-free branch, which no
+	// other test reaches: recycle's bitcoin tests exercise a different script.
+	t.Run("purchase", func(t *testing.T) {
+		receiverPk := p2tr(t, p.ReceiverKey)
+		valid := spend{
+			prevouts: []*wire.TxOut{{Value: dust, PkScript: p2tr(t, key(t, 9))}},
+			outputs:  []*wire.TxOut{{Value: dust, PkScript: receiverPk}},
+		}
+
+		t.Run("valid", func(t *testing.T) {
+			require.NoError(t, run(t, s.Purchase, valid))
+		})
+
+		t.Run("reject_short_value", func(t *testing.T) {
+			c := valid.clone()
+			c.outputs[0].Value--
+			requireRejected(t, run(t, s.Purchase, c))
+		})
+
+		t.Run("reject_wrong_receiver", func(t *testing.T) {
+			c := valid.clone()
+			c.outputs[0].PkScript = p2tr(t, key(t, 7))
+			requireRejected(t, run(t, s.Purchase, c))
+		})
+	})
 }
 
 func TestParamsValidation(t *testing.T) {
@@ -532,6 +558,26 @@ func TestParamsValidation(t *testing.T) {
 		bad.Locktime = 0
 		_, err := covenant.Build(bad, minAmount)
 		require.ErrorContains(t, err, "locktime")
+	})
+
+	// Receiver == operator is the dangerous collapse: the operator could satisfy
+	// recycle while paying the top-up repayment to itself.
+	t.Run("rejects_reused_keys", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			set  func(*covenant.Params)
+		}{
+			{"receiver_is_operator", func(q *covenant.Params) { q.OperatorKey = q.ReceiverKey }},
+			{"receiver_is_sender", func(q *covenant.Params) { q.SenderKey = q.ReceiverKey }},
+			{"sender_is_operator", func(q *covenant.Params) { q.OperatorKey = q.SenderKey }},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				bad := p
+				tc.set(&bad)
+				_, err := covenant.Build(bad, minAmount)
+				require.ErrorContains(t, err, "distinct")
+			})
+		}
 	})
 
 	// RefundTopup only differs from Topup when the operator funded the whole

--- a/test/covenant/covenant_test.go
+++ b/test/covenant/covenant_test.go
@@ -153,8 +153,20 @@ func assetID(index uint16) asset.AssetId {
 	return asset.AssetId{Txid: txid, Index: index}
 }
 
+// reversedAssetID flips the txid byte order. The id must be in chainhash
+// internal order; the reversed display hex is the classic way to get it wrong.
+func reversedAssetID(id *asset.AssetId) *asset.AssetId {
+	out := *id
+	for i, j := 0, len(out.Txid)-1; i < j; i, j = i+1, j-1 {
+		out.Txid[i], out.Txid[j] = out.Txid[j], out.Txid[i]
+	}
+	return &out
+}
+
 // packetOf builds a single-group packet. Zero amounts are omitted, so a receiver
 // holding none of the asset genuinely has no entry, which drives the miss path.
+// A packet need not balance: arkd is not involved here, so an unbalanced one
+// isolates the covenant's own arithmetic.
 func packetOf(
 	t *testing.T, id asset.AssetId, ins, outs map[uint16]uint64,
 ) asset.Packet {
@@ -284,12 +296,8 @@ func TestRecycle(t *testing.T) {
 	// The byte-order trap. A covenant built from a reversed txid can never match
 	// a real packet; it must fail loudly rather than pass vacuously.
 	t.Run("reject_reversed_asset_txid", func(t *testing.T) {
-		reversed := *p.AssetID
-		for i, j := 0, len(reversed.Txid)-1; i < j; i, j = i+1, j-1 {
-			reversed.Txid[i], reversed.Txid[j] = reversed.Txid[j], reversed.Txid[i]
-		}
 		bad := p
-		bad.AssetID = &reversed
+		bad.AssetID = reversedAssetID(p.AssetID)
 		badScripts, err := covenant.Build(bad, minAmount)
 		require.NoError(t, err)
 		requireRejected(t, run(t, badScripts.Recycle, valid(20)))
@@ -323,6 +331,33 @@ func TestPurchase(t *testing.T) {
 	t.Run("reject_wrong_receiver", func(t *testing.T) {
 		c := valid.clone()
 		c.outputs[0].PkScript = p2tr(t, key(t, 7))
+		requireRejected(t, run(t, s.Purchase, c))
+	})
+
+	// Purchase enforces the asset constraint with the same required-lookup
+	// pattern as recycle, so it needs the same rejection coverage: the
+	// silent-pass mode these guard against is the defect this design fixes.
+	t.Run("reject_foreign_asset_id", func(t *testing.T) {
+		c := valid.clone()
+		c.packet = packetOf(t, assetID(7),
+			map[uint16]uint64{0: 100}, map[uint16]uint64{0: 100},
+		)
+		requireRejected(t, run(t, s.Purchase, c))
+	})
+
+	t.Run("reject_reversed_asset_txid", func(t *testing.T) {
+		bad := p
+		bad.AssetID = reversedAssetID(p.AssetID)
+		badScripts, err := covenant.Build(bad, minAmount)
+		require.NoError(t, err)
+		requireRejected(t, run(t, badScripts.Purchase, valid))
+	})
+
+	t.Run("reject_asset_amount_shorted", func(t *testing.T) {
+		c := valid.clone()
+		c.packet = packetOf(t, *p.AssetID,
+			map[uint16]uint64{0: 100}, map[uint16]uint64{0: 99},
+		)
 		requireRejected(t, run(t, s.Purchase, c))
 	})
 }
@@ -363,6 +398,74 @@ func TestRefund(t *testing.T) {
 	t.Run("reject_sender_payload_diverted", func(t *testing.T) {
 		c := valid.clone()
 		c.outputs[1].PkScript = subDust(t, key(t, 7))
+		requireRejected(t, run(t, s.Refund, c))
+	})
+
+	// Refund is the operator's and the sender's recovery route, so its asset
+	// constraint needs the same rejection coverage as the claim paths.
+	t.Run("reject_foreign_asset_id", func(t *testing.T) {
+		c := valid.clone()
+		c.packet = packetOf(t, assetID(7),
+			map[uint16]uint64{0: 7}, map[uint16]uint64{1: 7},
+		)
+		requireRejected(t, run(t, s.Refund, c))
+	})
+
+	t.Run("reject_reversed_asset_txid", func(t *testing.T) {
+		bad := p
+		bad.AssetID = reversedAssetID(p.AssetID)
+		badScripts, err := covenant.Build(bad, minAmount)
+		require.NoError(t, err)
+		requireRejected(t, run(t, badScripts.Refund, valid))
+	})
+
+	t.Run("reject_asset_amount_shorted", func(t *testing.T) {
+		c := valid.clone()
+		c.packet = packetOf(t, *p.AssetID,
+			map[uint16]uint64{0: 7}, map[uint16]uint64{1: 6},
+		)
+		requireRejected(t, run(t, s.Refund, c))
+	})
+}
+
+// The refund path in bitcoin mode drops the asset clauses entirely and still has
+// to pin both sub-dust payouts, which TestRefund does not cover because it runs
+// with an asset.
+func TestBitcoinVariantRefund(t *testing.T) {
+	const payload = int64(50)
+
+	p := params(t, false)
+	p.Topup = dust - payload
+	s, err := covenant.Build(p, minAmount)
+	require.NoError(t, err)
+
+	// Topup is already below dust, so nothing is reserved and the operator
+	// recovers its advance whole.
+	topup := p.RefundTopup(minAmount)
+	require.Equal(t, dust-payload, topup)
+
+	valid := spend{
+		prevouts: []*wire.TxOut{{Value: dust, PkScript: p2tr(t, key(t, 9))}},
+		outputs: []*wire.TxOut{
+			{Value: topup, PkScript: subDust(t, p.OperatorKey)},
+			{Value: payload, PkScript: subDust(t, p.SenderKey)},
+		},
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, run(t, s.Refund, valid))
+	})
+
+	t.Run("reject_operator_shorted", func(t *testing.T) {
+		c := valid.clone()
+		c.outputs[0].Value--
+		c.outputs[1].Value++
+		requireRejected(t, run(t, s.Refund, c))
+	})
+
+	t.Run("reject_p2tr_where_subdust_required", func(t *testing.T) {
+		c := valid.clone()
+		c.outputs[1].PkScript = p2tr(t, p.SenderKey)
 		requireRejected(t, run(t, s.Refund, c))
 	})
 }

--- a/test/covenant/covenant_test.go
+++ b/test/covenant/covenant_test.go
@@ -1,0 +1,422 @@
+package covenant_test
+
+import (
+	"testing"
+
+	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/arkade-os/emulator/pkg/arkade"
+	"github.com/arkade-os/emulator/test/covenant"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// These run the covenants through the arkade engine directly: no arkd, no
+// emulator, no regtest stack. They cover everything the covenant itself decides.
+// They do not cover arkd's validation (asset balance, output minimums) or the
+// tapscript closures' signature and timelock requirements, both of which the
+// design depends on separately.
+
+const (
+	dust      = int64(330)
+	minAmount = int64(1)
+)
+
+type prevOutFetcher struct {
+	txscript.PrevOutputFetcher
+}
+
+func (prevOutFetcher) FetchPrevOutArkTx(wire.OutPoint) *wire.MsgTx { return nil }
+
+// OP_INSPECTINPUTSCRIPTPUBKEY reads this, not FetchPrevOutput. Returning nil
+// here makes every covenant that inspects an input fail before reaching the
+// condition under test, which turns rejection tests green for the wrong reason.
+func (f prevOutFetcher) FetchVtxoPrevOutPkScript(op wire.OutPoint) []byte {
+	prev := f.FetchPrevOutput(op)
+	if prev == nil {
+		return nil
+	}
+	return prev.PkScript
+}
+
+func key(t *testing.T, seed byte) *btcec.PublicKey {
+	t.Helper()
+	buf := make([]byte, 32)
+	buf[31] = seed
+	_, pub := btcec.PrivKeyFromBytes(buf)
+	return pub
+}
+
+func p2tr(t *testing.T, k *btcec.PublicKey) []byte {
+	t.Helper()
+	s, err := script.P2TRScript(k)
+	require.NoError(t, err)
+	return s
+}
+
+func subDust(t *testing.T, k *btcec.PublicKey) []byte {
+	t.Helper()
+	s, err := script.SubDustScript(k)
+	require.NoError(t, err)
+	return s
+}
+
+type spend struct {
+	prevouts []*wire.TxOut
+	outputs  []*wire.TxOut
+	packet   asset.Packet
+}
+
+func (s spend) clone() spend {
+	out := spend{
+		prevouts: make([]*wire.TxOut, len(s.prevouts)),
+		outputs:  make([]*wire.TxOut, len(s.outputs)),
+		packet:   s.packet,
+	}
+	for i, p := range s.prevouts {
+		cp := *p
+		out.prevouts[i] = &cp
+	}
+	for i, o := range s.outputs {
+		cp := *o
+		out.outputs[i] = &cp
+	}
+	return out
+}
+
+// run executes the covenant as input 0 of a synthetic transaction.
+func run(t *testing.T, script []byte, s spend) error {
+	t.Helper()
+	require.NotEmpty(t, s.prevouts)
+
+	tx := &wire.MsgTx{Version: 2}
+	prevouts := make(map[wire.OutPoint]*wire.TxOut, len(s.prevouts))
+	for i, prev := range s.prevouts {
+		op := wire.OutPoint{Hash: chainhash.Hash{byte(i + 1)}, Index: 0}
+		tx.AddTxIn(&wire.TxIn{PreviousOutPoint: op, Sequence: 0xfffffffd})
+		prevouts[op] = prev
+	}
+	for _, o := range s.outputs {
+		tx.AddTxOut(o)
+	}
+
+	fetcher := prevOutFetcher{txscript.NewMultiPrevOutFetcher(prevouts)}
+	engine, err := arkade.NewEngine(
+		script, tx, 0,
+		txscript.NewSigCache(10),
+		txscript.NewTxSigHashes(tx, fetcher),
+		s.prevouts[0].Value,
+		fetcher,
+	)
+	require.NoError(t, err)
+
+	if s.packet != nil {
+		engine.SetAssetPacket(s.packet)
+	}
+	return engine.Execute()
+}
+
+// requireRejected asserts the covenant rejected the spend by evaluating to
+// false, not by failing to run. Index and stack errors mean the script aborted
+// before reaching the condition under test -- a harness bug that would otherwise
+// show up as a passing rejection test.
+func requireRejected(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+
+	var scriptErr txscript.Error
+	require.ErrorAs(t, err, &scriptErr, "expected a script error, got %v", err)
+
+	switch scriptErr.ErrorCode {
+	case txscript.ErrEvalFalse, txscript.ErrVerify, txscript.ErrEqualVerify,
+		txscript.ErrNumEqualVerify:
+	default:
+		t.Fatalf(
+			"covenant aborted instead of evaluating false: %s (%v)",
+			scriptErr.ErrorCode, err,
+		)
+	}
+}
+
+// assetID is arbitrary but must never equal the spending transaction's own hash,
+// which the engine rejects as a fresh-issuance identity collision.
+func assetID(index uint16) asset.AssetId {
+	var txid chainhash.Hash
+	for i := range txid {
+		txid[i] = 0xab
+	}
+	return asset.AssetId{Txid: txid, Index: index}
+}
+
+// packetOf builds a single-group packet. Zero amounts are omitted, so a receiver
+// holding none of the asset genuinely has no entry, which drives the miss path.
+func packetOf(
+	t *testing.T, id asset.AssetId, ins, outs map[uint16]uint64,
+) asset.Packet {
+	t.Helper()
+	assetIns := make([]asset.AssetInput, 0, len(ins))
+	for vin, amt := range ins {
+		if amt == 0 {
+			continue
+		}
+		in, err := asset.NewAssetInput(vin, amt)
+		require.NoError(t, err)
+		assetIns = append(assetIns, *in)
+	}
+	assetOuts := make([]asset.AssetOutput, 0, len(outs))
+	for vout, amt := range outs {
+		if amt == 0 {
+			continue
+		}
+		out, err := asset.NewAssetOutput(vout, amt)
+		require.NoError(t, err)
+		assetOuts = append(assetOuts, *out)
+	}
+	grp, err := asset.NewAssetGroup(&id, nil, assetIns, assetOuts, []asset.Metadata{})
+	require.NoError(t, err)
+	pkt, err := asset.NewPacket([]asset.AssetGroup{*grp})
+	require.NoError(t, err)
+	return pkt
+}
+
+func params(t *testing.T, withAsset bool) covenant.Params {
+	t.Helper()
+	p := covenant.Params{
+		ReceiverKey: key(t, 1),
+		SenderKey:   key(t, 2),
+		OperatorKey: key(t, 3),
+		Dust:        dust,
+		Topup:       dust,
+		Locktime:    500_000_000,
+	}
+	if withAsset {
+		id := assetID(0)
+		p.AssetID = &id
+	}
+	return p
+}
+
+func TestRecycle(t *testing.T) {
+	p := params(t, true)
+	s, err := covenant.Build(p, minAmount)
+	require.NoError(t, err)
+
+	receiverPk := p2tr(t, p.ReceiverKey)
+
+	// Topup == Dust, so the operator payout sits at the dust floor and pins P2TR.
+	valid := func(priorUnits uint64) spend {
+		return spend{
+			prevouts: []*wire.TxOut{
+				{Value: dust, PkScript: p2tr(t, key(t, 9))},
+				{Value: dust, PkScript: receiverPk},
+			},
+			outputs: []*wire.TxOut{
+				{Value: p.Topup, PkScript: p2tr(t, p.OperatorKey)},
+				{Value: dust, PkScript: receiverPk},
+			},
+			packet: packetOf(t, *p.AssetID,
+				map[uint16]uint64{0: 1, 1: priorUnits},
+				map[uint16]uint64{1: 1 + priorUnits},
+			),
+		}
+	}
+
+	t.Run("receiver_holds_prior_balance", func(t *testing.T) {
+		require.NoError(t, run(t, s.Recycle, valid(20)))
+	})
+
+	// The design's central claim: one script serves a receiver with no prior
+	// holding, because a lookup miss returns (0, 0) and the flag is dropped.
+	t.Run("receiver_holds_zero", func(t *testing.T) {
+		require.NoError(t, run(t, s.Recycle, valid(0)))
+	})
+
+	t.Run("reject_wrong_receiver", func(t *testing.T) {
+		c := valid(20).clone()
+		c.outputs[1].PkScript = p2tr(t, key(t, 7))
+		requireRejected(t, run(t, s.Recycle, c))
+	})
+
+	t.Run("reject_operator_underpaid", func(t *testing.T) {
+		c := valid(20).clone()
+		c.outputs[0].Value--
+		c.outputs[1].Value++
+		requireRejected(t, run(t, s.Recycle, c))
+	})
+
+	t.Run("reject_extra_input", func(t *testing.T) {
+		c := valid(20).clone()
+		c.prevouts = append(c.prevouts, &wire.TxOut{Value: 1000, PkScript: receiverPk})
+		requireRejected(t, run(t, s.Recycle, c))
+	})
+
+	t.Run("reject_wrong_account_at_input_one", func(t *testing.T) {
+		c := valid(20).clone()
+		c.prevouts[1].PkScript = p2tr(t, p.SenderKey)
+		requireRejected(t, run(t, s.Recycle, c))
+	})
+
+	t.Run("reject_asset_amount_shorted", func(t *testing.T) {
+		c := valid(20).clone()
+		c.packet = packetOf(t, *p.AssetID,
+			map[uint16]uint64{0: 1, 1: 20},
+			map[uint16]uint64{0: 1, 1: 20},
+		)
+		requireRejected(t, run(t, s.Recycle, c))
+	})
+
+	// Documents a limitation, not a guarantee. A foreign AssetID misses on every
+	// lookup, so the sum clause degenerates to 0 == 0 + 0 and the covenant
+	// accepts. Only arkd's asset-balance validation rejects such a spend, so this
+	// covenant must never be deployed against a validator that omits that check.
+	t.Run("foreign_asset_id_not_caught_by_covenant_alone", func(t *testing.T) {
+		c := valid(20).clone()
+		c.packet = packetOf(t, assetID(7),
+			map[uint16]uint64{0: 1, 1: 20},
+			map[uint16]uint64{1: 21},
+		)
+		require.NoError(t, run(t, s.Recycle, c))
+	})
+}
+
+func TestPurchase(t *testing.T) {
+	p := params(t, true)
+	s, err := covenant.Build(p, minAmount)
+	require.NoError(t, err)
+
+	receiverPk := p2tr(t, p.ReceiverKey)
+	valid := spend{
+		prevouts: []*wire.TxOut{{Value: dust, PkScript: p2tr(t, key(t, 9))}},
+		outputs:  []*wire.TxOut{{Value: dust, PkScript: receiverPk}},
+		packet: packetOf(t, *p.AssetID,
+			map[uint16]uint64{0: 100}, map[uint16]uint64{0: 100},
+		),
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, run(t, s.Purchase, valid))
+	})
+
+	t.Run("reject_short_value", func(t *testing.T) {
+		c := valid.clone()
+		c.outputs[0].Value--
+		requireRejected(t, run(t, s.Purchase, c))
+	})
+
+	t.Run("reject_wrong_receiver", func(t *testing.T) {
+		c := valid.clone()
+		c.outputs[0].PkScript = p2tr(t, key(t, 7))
+		requireRejected(t, run(t, s.Purchase, c))
+	})
+}
+
+// The refund covenant is where sub-dust pinning bites: with Topup == Dust the
+// operator recovers Dust-1, itself below dust, so both payouts pin OP_RETURN.
+func TestRefund(t *testing.T) {
+	p := params(t, true)
+	s, err := covenant.Build(p, minAmount)
+	require.NoError(t, err)
+
+	topup := p.RefundTopup(minAmount)
+	require.Equal(t, dust-minAmount, topup)
+
+	valid := spend{
+		prevouts: []*wire.TxOut{{Value: dust, PkScript: p2tr(t, key(t, 9))}},
+		outputs: []*wire.TxOut{
+			{Value: topup, PkScript: subDust(t, p.OperatorKey)},
+			{Value: dust - topup, PkScript: subDust(t, p.SenderKey)},
+		},
+		packet: packetOf(t, *p.AssetID,
+			map[uint16]uint64{0: 7}, map[uint16]uint64{1: 7},
+		),
+	}
+
+	t.Run("valid_subdust_pins", func(t *testing.T) {
+		require.NoError(t, run(t, s.Refund, valid))
+	})
+
+	// Pinning a below-dust payout as P2TR is the silent-unspendability trap the
+	// design warns about; the covenant must reject it.
+	t.Run("reject_p2tr_where_subdust_required", func(t *testing.T) {
+		c := valid.clone()
+		c.outputs[0].PkScript = p2tr(t, p.OperatorKey)
+		requireRejected(t, run(t, s.Refund, c))
+	})
+
+	t.Run("reject_sender_payload_diverted", func(t *testing.T) {
+		c := valid.clone()
+		c.outputs[1].PkScript = subDust(t, key(t, 7))
+		requireRejected(t, run(t, s.Refund, c))
+	})
+}
+
+// Bitcoin payload: no asset packet at all, and the operator's repayment is
+// Dust-payload, below dust, so it pins sub-dust.
+func TestBitcoinVariant(t *testing.T) {
+	const payload = int64(50)
+
+	p := params(t, false)
+	p.Topup = dust - payload
+	s, err := covenant.Build(p, minAmount)
+	require.NoError(t, err)
+
+	receiverPk := p2tr(t, p.ReceiverKey)
+	valid := spend{
+		prevouts: []*wire.TxOut{
+			{Value: dust, PkScript: p2tr(t, key(t, 9))},
+			{Value: dust, PkScript: receiverPk},
+		},
+		outputs: []*wire.TxOut{
+			{Value: p.Topup, PkScript: subDust(t, p.OperatorKey)},
+			{Value: dust + payload, PkScript: receiverPk},
+		},
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, run(t, s.Recycle, valid))
+		require.Equal(t, payload, valid.outputs[1].Value-valid.prevouts[1].Value,
+			"receiver gains exactly the payload")
+		require.Equal(t, dust-payload, valid.outputs[0].Value,
+			"operator is made whole")
+	})
+
+	t.Run("reject_receiver_overpaid", func(t *testing.T) {
+		c := valid.clone()
+		c.outputs[0].Value--
+		c.outputs[1].Value++
+		requireRejected(t, run(t, s.Recycle, c))
+	})
+}
+
+func TestParamsValidation(t *testing.T) {
+	p := params(t, false)
+
+	t.Run("rejects_topup_above_dust", func(t *testing.T) {
+		bad := p
+		bad.Topup = dust + 1
+		_, err := covenant.Build(bad, minAmount)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects_topup_below_min", func(t *testing.T) {
+		bad := p
+		bad.Topup = 0
+		_, err := covenant.Build(bad, minAmount)
+		require.Error(t, err)
+	})
+
+	// RefundTopup only differs from Topup when the operator funded the whole
+	// dust unit; that single sat is the cost of an abandoned asset payment.
+	t.Run("refund_topup_reserves_one_min_amount_only_when_fully_funded", func(t *testing.T) {
+		full := p
+		full.Topup = dust
+		require.Equal(t, dust-minAmount, full.RefundTopup(minAmount))
+
+		partial := p
+		partial.Topup = dust - 50
+		require.Equal(t, dust-50, partial.RefundTopup(minAmount))
+	})
+}

--- a/test/covenant/covenant_test.go
+++ b/test/covenant/covenant_test.go
@@ -422,6 +422,15 @@ func TestParamsValidation(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	// A zero absolute locktime is always satisfied, so the recovery leaf would be
+	// spendable the moment the covenant is funded.
+	t.Run("rejects_zero_locktime", func(t *testing.T) {
+		bad := p
+		bad.Locktime = 0
+		_, err := covenant.Build(bad, minAmount)
+		require.ErrorContains(t, err, "locktime")
+	})
+
 	// RefundTopup only differs from Topup when the operator funded the whole
 	// dust unit; that single sat is the cost of an abandoned asset payment.
 	t.Run("refund_topup_reserves_one_min_amount_only_when_fully_funded", func(t *testing.T) {

--- a/test/covenant/covenant_test.go
+++ b/test/covenant/covenant_test.go
@@ -143,10 +143,12 @@ func requireRejected(t *testing.T, err error) {
 
 // assetID is arbitrary but must never equal the spending transaction's own hash,
 // which the engine rejects as a fresh-issuance identity collision.
+// Deliberately not palindromic, so reversing it produces a different value and
+// the byte-order test means something.
 func assetID(index uint16) asset.AssetId {
 	var txid chainhash.Hash
 	for i := range txid {
-		txid[i] = 0xab
+		txid[i] = byte(i + 1)
 	}
 	return asset.AssetId{Txid: txid, Index: index}
 }
@@ -268,17 +270,29 @@ func TestRecycle(t *testing.T) {
 		requireRejected(t, run(t, s.Recycle, c))
 	})
 
-	// Documents a limitation, not a guarantee. A foreign AssetID misses on every
-	// lookup, so the sum clause degenerates to 0 == 0 + 0 and the covenant
-	// accepts. Only arkd's asset-balance validation rejects such a spend, so this
-	// covenant must never be deployed against a validator that omits that check.
-	t.Run("foreign_asset_id_not_caught_by_covenant_alone", func(t *testing.T) {
+	// Before the found-flag was verified this passed: every lookup missed, the
+	// sum degenerated to 0 == 0 + 0, and the asset constraint went unenforced.
+	t.Run("reject_foreign_asset_id", func(t *testing.T) {
 		c := valid(20).clone()
 		c.packet = packetOf(t, assetID(7),
 			map[uint16]uint64{0: 1, 1: 20},
 			map[uint16]uint64{1: 21},
 		)
-		require.NoError(t, run(t, s.Recycle, c))
+		requireRejected(t, run(t, s.Recycle, c))
+	})
+
+	// The byte-order trap. A covenant built from a reversed txid can never match
+	// a real packet; it must fail loudly rather than pass vacuously.
+	t.Run("reject_reversed_asset_txid", func(t *testing.T) {
+		reversed := *p.AssetID
+		for i, j := 0, len(reversed.Txid)-1; i < j; i, j = i+1, j-1 {
+			reversed.Txid[i], reversed.Txid[j] = reversed.Txid[j], reversed.Txid[i]
+		}
+		bad := p
+		bad.AssetID = &reversed
+		badScripts, err := covenant.Build(bad, minAmount)
+		require.NoError(t, err)
+		requireRejected(t, run(t, badScripts.Recycle, valid(20)))
 	})
 }
 

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -1,0 +1,180 @@
+package test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/arkade-os/emulator/pkg/arkade"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/stretchr/testify/require"
+)
+
+// ARKD_VTXO_MIN_AMOUNT=1 in docker-compose.regtest.yml:99. Not exposed by GetInfo.
+const dustCovenantVtxoMinAmount = int64(1)
+
+const (
+	leafRecycle = iota
+	leafPurchase
+	leafRefundSender
+	leafRecovery
+)
+
+type dustCovenantParams struct {
+	receiverKey *btcec.PublicKey
+	senderKey   *btcec.PublicKey
+	operatorKey *btcec.PublicKey
+	dust        int64
+	topup       int64
+	assetID     *asset.AssetId
+	locktime    arklib.AbsoluteLocktime
+}
+
+// refundTopup is what the operator recovers on the refund leaves. It falls below
+// topup only when the operator funded the whole dust unit, where one
+// vtxoMinAmount must stay behind to host the sender's returned asset.
+func (p dustCovenantParams) refundTopup(vtxoMinAmount int64) int64 {
+	if capped := p.dust - vtxoMinAmount; p.topup > capped {
+		return capped
+	}
+	return p.topup
+}
+
+// pinOutput binds an output to a key. pushScriptPubKey reports a witness program
+// as (program, version) but anything else as (sha256(script), -1), so a
+// below-dust output must be pinned in its sub-dust OP_RETURN form.
+func pinOutput(
+	t *testing.T, b *txscript.ScriptBuilder, vout int64, key *btcec.PublicKey, value, dust int64,
+) {
+	t.Helper()
+	b.AddInt64(vout).AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY)
+	if value >= dust {
+		b.AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
+			AddData(schnorr.SerializePubKey(key)).AddOp(arkade.OP_EQUALVERIFY)
+		return
+	}
+	subDust, err := script.SubDustScript(key)
+	require.NoError(t, err)
+	h := sha256.Sum256(subDust)
+	b.AddInt64(-1).AddOp(arkade.OP_EQUALVERIFY).
+		AddData(h[:]).AddOp(arkade.OP_EQUALVERIFY)
+}
+
+// appendAssetLookup leaves the asset amount on the stack, dropping the found
+// flag: a miss pushes (0, 0), which is exactly "holds none of this asset".
+// id.Txid must be internal byte order, never the reversed display hex.
+func appendAssetLookup(b *txscript.ScriptBuilder, idx int64, id *asset.AssetId, output bool) {
+	op := byte(arkade.OP_INSPECTINASSETLOOKUP)
+	if output {
+		op = byte(arkade.OP_INSPECTOUTASSETLOOKUP)
+	}
+	b.AddInt64(idx).AddData(id.Txid[:]).AddInt64(int64(id.Index)).
+		AddOp(op).AddOp(arkade.OP_DROP)
+}
+
+func buildPurchaseCovenant(t *testing.T, p dustCovenantParams) []byte {
+	t.Helper()
+	b := txscript.NewScriptBuilder().
+		AddOp(arkade.OP_PUSHCURRENTINPUTINDEX).AddInt64(0).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
+		AddData(schnorr.SerializePubKey(p.receiverKey)).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddInt64(0).AddOp(arkade.OP_INSPECTINPUTVALUE).AddOp(arkade.OP_EQUALVERIFY)
+
+	if p.assetID == nil {
+		b.AddOp(arkade.OP_1)
+	} else {
+		appendAssetLookup(b, 0, p.assetID, true)
+		appendAssetLookup(b, 0, p.assetID, false)
+		b.AddOp(arkade.OP_EQUAL)
+	}
+
+	s, err := b.Script()
+	require.NoError(t, err)
+	return s
+}
+
+func buildDustCovenantVtxoScript(
+	server, emulator, sender *btcec.PublicKey,
+	p dustCovenantParams,
+	recycle, purchase, refund []byte,
+) script.TapscriptsVtxoScript {
+	tweak := func(s []byte) *btcec.PublicKey {
+		return arkade.ComputeArkadeScriptPublicKey(emulator, arkade.ArkadeScriptHash(s))
+	}
+	return script.TapscriptsVtxoScript{
+		Closures: []script.Closure{
+			&script.MultisigClosure{PubKeys: []*btcec.PublicKey{server, tweak(recycle)}},
+			&script.MultisigClosure{PubKeys: []*btcec.PublicKey{server, tweak(purchase)}},
+			&script.MultisigClosure{PubKeys: []*btcec.PublicKey{server, sender, tweak(refund)}},
+			&script.CLTVMultisigClosure{
+				MultisigClosure: script.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{server, tweak(refund)},
+				},
+				Locktime: p.locktime,
+			},
+		},
+	}
+}
+
+// onlyForfeitScript requires exactly one forfeit closure; this taptree has four.
+func tapscriptAt(t *testing.T, vtxoScript script.TapscriptsVtxoScript, i int) []byte {
+	t.Helper()
+	s, err := vtxoScript.Closures[i].Script()
+	require.NoError(t, err)
+	return s
+}
+
+func TestDustCovenant(t *testing.T) {
+	ctx := t.Context()
+
+	sender, senderWallet, senderPubKey, grpcSender := setupArkSDKwithPublicKey(t)
+	t.Cleanup(func() { grpcSender.Close() })
+	senderAddr := fundAndSettleAlice(t, ctx, sender, 100_000)
+
+	receiver, _, receiverPubKey, grpcReceiver := setupArkSDKwithPublicKey(t)
+	t.Cleanup(func() { grpcReceiver.Close() })
+	_ = fundAndSettleAlice(t, ctx, receiver, 100_000)
+
+	operator, operatorWallet, operatorPubKey, grpcOperator := setupArkSDKwithPublicKey(t)
+	t.Cleanup(func() { grpcOperator.Close() })
+	_ = fundAndSettleAlice(t, ctx, operator, 100_000)
+
+	emulator, emulatorPubKey, conn := setupEmulatorClient(t, ctx)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	indexerSvc := setupIndexer(t)
+
+	infos, err := grpcSender.GetInfo(ctx)
+	require.NoError(t, err)
+	checkpointScript, err := hex.DecodeString(infos.CheckpointTapscript)
+	require.NoError(t, err)
+
+	server := senderAddr.Signer
+	dust := int64(infos.Dust)
+	require.Greater(t, dust, dustCovenantVtxoMinAmount,
+		"sub-dust outputs need ARKD_VTXO_MIN_AMOUNT below dust")
+
+	_ = emulator
+	_ = senderWallet
+	_ = operatorWallet
+	_ = operator
+	_ = receiver
+	_ = indexerSvc
+	_ = checkpointScript
+	_ = server
+	_ = senderPubKey
+	_ = receiverPubKey
+	_ = operatorPubKey
+	_ = emulatorPubKey
+
+	t.Run("purchase/valid", func(t *testing.T) {
+		t.Fatal("not implemented")
+	})
+}

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -167,73 +167,82 @@ func TestDustCovenant(t *testing.T) {
 		}
 	}
 
-	// senderVout is where buildWalletFundedTx puts the sender's change: it is
-	// appended after the outputs we ask for. The sender's share of a mint rides
-	// on that change output rather than on an output of its own, because
-	// buildWalletFundedTx sends change to the sender's account script -- the same
-	// script -- and findTaprootOutput picks the first output matching it. Two
-	// outputs with that script make the next call resolve the wrong index
-	// (utils_test.go:560).
-	const senderVout = uint32(1)
+	// submitWithArkd goes straight to arkd, so the SDK's ListVtxos never learns
+	// the VTXO was spent and buildWalletFundedTx keeps handing back inputs this
+	// test already consumed. The sender's funding VTXO is therefore resolved once
+	// and threaded by hand. Every funding transaction lays its outputs out the
+	// same way:
+	//
+	//	[0] receiver account, dust
+	//	[1] sender account, dust, carrying the sender's asset
+	//	[2] sender change, re-points senderFunding
+	senderFunding := findAccountInput(t, ctx, sender, indexerSvc, *senderAccount)
 
-	// fundAccounts gives the receiver a dust account and leaves the rest as the
-	// sender's change. No asset packet.
-	fundAccounts := func(t *testing.T) *wire.MsgTx {
+	fundAccounts := func(t *testing.T, packet *asset.Packet) *wire.MsgTx {
 		t.Helper()
-		tx, cps := buildWalletFundedTx(
-			t, ctx, sender, indexerSvc, senderPubKey, server, exitDelay,
-			[]*wire.TxOut{{Value: dust, PkScript: receiverAccountPk}}, checkpointScript,
-		)
-		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
-		return tx.UnsignedTx
-	}
-
-	// mint does the same and issues an asset across both outputs. Issuance must
-	// happen in its own transaction: the covenant pins the AssetID, which for an
-	// issuance derives from that transaction's own txid, so issuing inside the
-	// lockup would make the address depend on a txid that depends on the address.
-	mint := func(
-		t *testing.T, receiverUnits, senderUnits uint64,
-	) (*wire.MsgTx, asset.AssetId) {
-		t.Helper()
-		tx, cps := buildWalletFundedTx(
-			t, ctx, sender, indexerSvc, senderPubKey, server, exitDelay,
-			[]*wire.TxOut{{Value: dust, PkScript: receiverAccountPk}}, checkpointScript,
-		)
-		addAssetPacketToTx(t, tx, issuancePacket(t, map[uint16]uint64{
-			0:                  receiverUnits,
-			uint16(senderVout): senderUnits,
-		}))
-		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
-		h := tx.UnsignedTx.TxHash()
-		return tx.UnsignedTx, asset.AssetId{Txid: [asset.TX_HASH_SIZE]byte(h), Index: 0}
-	}
-
-	// lockup spends the sender's change into the covenant, returning the balance
-	// as fresh change so the sender's bitcoin is not burned as fee.
-	lockup := func(
-		t *testing.T, mintTx *wire.MsgTx, c dustContract, units uint64,
-	) *wire.MsgTx {
-		t.Helper()
-		in := vtxoInputFromScriptOutput(
-			t, mintTx, senderVout, *senderAccount, onlyForfeitScript(t, *senderAccount),
-		)
-		change := in.Amount - c.params.Dust
+		change := senderFunding.Amount - 2*dust
 		require.Positive(t, change)
 
 		tx, cps, err := offchain.BuildTxs(
-			[]offchain.VtxoInput{in},
+			[]offchain.VtxoInput{senderFunding},
 			[]*wire.TxOut{
-				{Value: c.params.Dust, PkScript: c.pkScript},
+				{Value: dust, PkScript: receiverAccountPk},
+				{Value: dust, PkScript: senderAccountPk},
 				{Value: change, PkScript: senderAccountPk},
 			},
 			checkpointScript,
 		)
 		require.NoError(t, err)
+		if packet != nil {
+			addAssetPacketToTx(t, tx, *packet)
+		}
+		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
+
+		senderFunding = vtxoInputFromScriptOutput(
+			t, tx.UnsignedTx, 2, *senderAccount, onlyForfeitScript(t, *senderAccount),
+		)
+		return tx.UnsignedTx
+	}
+
+	// mint issues a fresh asset. Issuance must happen in its own transaction: the
+	// covenant pins the AssetID, which for an issuance derives from that
+	// transaction's own txid, so issuing inside the lockup would make the address
+	// depend on a txid that depends on the address.
+	mint := func(
+		t *testing.T, receiverUnits, senderUnits uint64,
+	) (*wire.MsgTx, asset.AssetId) {
+		t.Helper()
+		amounts := map[uint16]uint64{1: senderUnits}
+		if receiverUnits > 0 {
+			amounts[0] = receiverUnits
+		}
+		packet := issuancePacket(t, amounts)
+		tx := fundAccounts(t, &packet)
+		h := tx.TxHash()
+		return tx, asset.AssetId{Txid: [asset.TX_HASH_SIZE]byte(h), Index: 0}
+	}
+
+	// lockup spends the sender's whole dust account into the covenant, so there is
+	// no change and the sender's bitcoin commitment stays at exactly one dust unit.
+	lockup := func(
+		t *testing.T, fundTx *wire.MsgTx, c dustContract, units uint64,
+	) *wire.MsgTx {
+		t.Helper()
+		in := vtxoInputFromScriptOutput(
+			t, fundTx, 1, *senderAccount, onlyForfeitScript(t, *senderAccount),
+		)
+		require.Equal(t, c.params.Dust, in.Amount)
+
+		tx, cps, err := offchain.BuildTxs(
+			[]offchain.VtxoInput{in},
+			[]*wire.TxOut{{Value: c.params.Dust, PkScript: c.pkScript}},
+			checkpointScript,
+		)
+		require.NoError(t, err)
 		if c.params.AssetID != nil {
-			// vin is the transaction input index, not the mint's output index.
+			// vin is the transaction input index, not the funding output index.
 			addAssetPacketToTx(t, tx, createTransferAssetPacket(
-				t, mintTx.TxHash(), 0, 0, 0, units,
+				t, fundTx.TxHash(), 0, 0, 0, units,
 			))
 		}
 		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
@@ -404,7 +413,7 @@ func TestDustCovenant(t *testing.T) {
 
 		// No asset anywhere: the bitcoin variant omits the asset clauses, and an
 		// unaccounted asset on the input would be rejected by arkd.
-		fundTx := fundAccounts(t)
+		fundTx := fundAccounts(t, nil)
 
 		p := baseParams()
 		p.Topup = dust - payload

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -119,12 +119,23 @@ func TestDustCovenant(t *testing.T) {
 	t.Cleanup(func() { grpcSender.Close() })
 	senderAddr := fundAndSettleAlice(t, ctx, sender, 100_000)
 
-	receiver, _, receiverPubKey, grpcReceiver := setupArkSDKwithPublicKey(t)
+	receiver, receiverWallet, receiverPubKey, grpcReceiver := setupArkSDKwithPublicKey(t)
 	t.Cleanup(func() { grpcReceiver.Close() })
 	_ = fundAndSettleAlice(t, ctx, receiver, 100_000)
 
 	_, _, operatorPubKey, grpcOperator := setupArkSDKwithPublicKey(t)
 	t.Cleanup(func() { grpcOperator.Close() })
+
+	// A separate identity pays for every funding transaction. Sighash commits to
+	// the prevout amount, and the wallet resolves an input by script, so two
+	// outputs sharing a script in one transaction make it sign for the wrong
+	// amount and produce an invalid checkpoint signature. The sender's account
+	// script is the only one their wallet can sign, so the sender cannot both
+	// hold a dust output and take change. A funder gives every output in a
+	// funding transaction a distinct script.
+	funder, funderWallet, funderPubKey, grpcFunder := setupArkSDKwithPublicKey(t)
+	t.Cleanup(func() { grpcFunder.Close() })
+	_ = fundAndSettleAlice(t, ctx, funder, 200_000)
 
 	emulator, emulatorPubKey, conn := setupEmulatorClient(t, ctx)
 	t.Cleanup(func() { _ = conn.Close() })
@@ -167,28 +178,31 @@ func TestDustCovenant(t *testing.T) {
 		}
 	}
 
+	funderAccount := defaultVtxoScript(funderPubKey, server, exitDelay)
+	funderAccountPk := p2trScriptForVtxoScript(t, *funderAccount)
+
 	// submitWithArkd goes straight to arkd, so the SDK's ListVtxos never learns
 	// the VTXO was spent and buildWalletFundedTx keeps handing back inputs this
-	// test already consumed. The sender's funding VTXO is therefore resolved once
-	// and threaded by hand. Every funding transaction lays its outputs out the
-	// same way:
+	// test already consumed. The funder's VTXO is resolved once and threaded by
+	// hand. Every funding transaction lays its outputs out the same way, each
+	// with a distinct script:
 	//
 	//	[0] receiver account, dust
 	//	[1] sender account, dust, carrying the sender's asset
-	//	[2] sender change, re-points senderFunding
-	senderFunding := findAccountInput(t, ctx, sender, indexerSvc, *senderAccount)
+	//	[2] funder change, re-points funderFunding
+	funderFunding := findAccountInput(t, ctx, funder, indexerSvc, *funderAccount)
 
 	fundAccounts := func(t *testing.T, packet *asset.Packet) *wire.MsgTx {
 		t.Helper()
-		change := senderFunding.Amount - 2*dust
+		change := funderFunding.Amount - 2*dust
 		require.Positive(t, change)
 
 		tx, cps, err := offchain.BuildTxs(
-			[]offchain.VtxoInput{senderFunding},
+			[]offchain.VtxoInput{funderFunding},
 			[]*wire.TxOut{
 				{Value: dust, PkScript: receiverAccountPk},
 				{Value: dust, PkScript: senderAccountPk},
-				{Value: change, PkScript: senderAccountPk},
+				{Value: change, PkScript: funderAccountPk},
 			},
 			checkpointScript,
 		)
@@ -201,11 +215,11 @@ func TestDustCovenant(t *testing.T) {
 		// observable fails with VTXO_NOT_FOUND. The subscription must be opened
 		// before submitting, and after the outputs are final.
 		confirmed := watchForPreconfirmedVtxos(t, indexerSvc, tx, 0, 1, 2)
-		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
+		submitWithArkd(t, ctx, tx, cps, funderWallet, grpcFunder)
 		confirmed()
 
-		senderFunding = vtxoInputFromScriptOutput(
-			t, tx.UnsignedTx, 2, *senderAccount, onlyForfeitScript(t, *senderAccount),
+		funderFunding = vtxoInputFromScriptOutput(
+			t, tx.UnsignedTx, 2, *funderAccount, onlyForfeitScript(t, *funderAccount),
 		)
 		return tx.UnsignedTx
 	}
@@ -259,11 +273,26 @@ func TestDustCovenant(t *testing.T) {
 		return tx.UnsignedTx
 	}
 
+	// Leaves other than refundSender carry no human key, so the emulator's
+	// signature is the only one a covenant-only spend needs.
 	submitToEmulator := func(t *testing.T, ptx *psbt.Packet, cps []*psbt.Packet) error {
 		t.Helper()
 		encoded, err := ptx.B64Encode()
 		require.NoError(t, err)
 		_, _, err = emulator.SubmitTx(ctx, encoded, encodeCheckpoints(t, cps))
+		return err
+	}
+
+	// A merge also spends the receiver's own account, so the receiver must sign
+	// the arkade transaction and its checkpoints. The emulator supplies only the
+	// covenant input's signature.
+	submitMerge := func(t *testing.T, ptx *psbt.Packet, cps []*psbt.Packet) error {
+		t.Helper()
+		signed, err := receiverWallet.SignTransaction(ctx, b64(t, ptx), nil)
+		require.NoError(t, err)
+		_, _, err = emulator.SubmitTx(
+			ctx, signed, signCheckpoints(t, ctx, receiverWallet, nil, cps),
+		)
 		return err
 	}
 
@@ -332,7 +361,7 @@ func TestDustCovenant(t *testing.T) {
 		})
 
 		require.NoError(t, executeArkadeScripts(t, claimTx, claimCps, emulatorPubKey))
-		require.NoError(t, submitToEmulator(t, claimTx, claimCps))
+		require.NoError(t, submitMerge(t, claimTx, claimCps))
 
 		require.Equal(t, accountIn.Amount, claimTx.UnsignedTx.TxOut[1].Value,
 			"receiver's bitcoin balance must be unchanged")
@@ -451,7 +480,7 @@ func TestDustCovenant(t *testing.T) {
 		})
 
 		require.NoError(t, executeArkadeScripts(t, claimTx, claimCps, emulatorPubKey))
-		require.NoError(t, submitToEmulator(t, claimTx, claimCps))
+		require.NoError(t, submitMerge(t, claimTx, claimCps))
 
 		require.Equal(t, payload, claimTx.UnsignedTx.TxOut[1].Value-accountIn.Amount,
 			"receiver must gain exactly the payload")

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -7,16 +7,22 @@ import (
 
 	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
+	"github.com/arkade-os/arkd/pkg/ark-lib/offchain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
 	"github.com/arkade-os/emulator/pkg/arkade"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
 
-// ARKD_VTXO_MIN_AMOUNT=1 in docker-compose.regtest.yml:99. Not exposed by GetInfo.
+// ARKD_VTXO_MIN_AMOUNT=1 in docker-compose.regtest.yml. Not exposed by GetInfo.
 const dustCovenantVtxoMinAmount = int64(1)
+
+// Genesis-era timestamp: always already satisfied, as in htlc_test.go.
+const dustCovenantLocktime = arklib.AbsoluteLocktime(500_000_000)
 
 const (
 	leafRecycle = iota
@@ -58,11 +64,29 @@ func pinOutput(
 			AddData(schnorr.SerializePubKey(key)).AddOp(arkade.OP_EQUALVERIFY)
 		return
 	}
-	subDust, err := script.SubDustScript(key)
-	require.NoError(t, err)
-	h := sha256.Sum256(subDust)
+	h := sha256.Sum256(subDustPkScript(t, key))
 	b.AddInt64(-1).AddOp(arkade.OP_EQUALVERIFY).
 		AddData(h[:]).AddOp(arkade.OP_EQUALVERIFY)
+}
+
+func subDustPkScript(t *testing.T, key *btcec.PublicKey) []byte {
+	t.Helper()
+	s, err := script.SubDustScript(key)
+	require.NoError(t, err)
+	return s
+}
+
+// payoutPkScript is the scriptPubKey a covenant-pinned payout must actually use:
+// P2TR at or above dust, sub-dust OP_RETURN below it. It must agree with
+// pinOutput or the covenant rejects its own intended spend.
+func payoutPkScript(t *testing.T, key *btcec.PublicKey, value, dust int64) []byte {
+	t.Helper()
+	if value >= dust {
+		s, err := script.P2TRScript(key)
+		require.NoError(t, err)
+		return s
+	}
+	return subDustPkScript(t, key)
 }
 
 // appendAssetLookup leaves the asset amount on the stack, dropping the found
@@ -77,6 +101,57 @@ func appendAssetLookup(b *txscript.ScriptBuilder, idx int64, id *asset.AssetId, 
 		AddOp(op).AddOp(arkade.OP_DROP)
 }
 
+func finishCovenant(t *testing.T, b *txscript.ScriptBuilder, hasAsset bool) []byte {
+	t.Helper()
+	if !hasAsset {
+		b.AddOp(arkade.OP_1)
+	}
+	s, err := b.Script()
+	require.NoError(t, err)
+	return s
+}
+
+// buildRecycleCovenant gates the receiver merging the covenant into an account
+// they already own, repaying the operator's advance in sats.
+//
+//	in[0] covenant, in[1] receiver account
+//	out[0] operator repaid topup, out[1] receiver's merged account
+//
+// Output value is enforced as a sum over both inputs rather than a constant, so
+// the receiver's prior balance is irrelevant.
+func buildRecycleCovenant(t *testing.T, p dustCovenantParams) []byte {
+	t.Helper()
+	b := txscript.NewScriptBuilder().
+		AddOp(arkade.OP_PUSHCURRENTINPUTINDEX).AddInt64(0).AddOp(arkade.OP_EQUALVERIFY).
+		AddOp(arkade.OP_INSPECTNUMINPUTS).AddInt64(2).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(1).AddOp(arkade.OP_INSPECTINPUTSCRIPTPUBKEY).
+		AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
+		AddData(schnorr.SerializePubKey(p.receiverKey)).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddInt64(p.topup).AddOp(arkade.OP_EQUALVERIFY)
+
+	pinOutput(t, b, 0, p.operatorKey, p.topup, p.dust)
+
+	b.AddInt64(1).AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY).
+		AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
+		AddData(schnorr.SerializePubKey(p.receiverKey)).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(1).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddInt64(0).AddOp(arkade.OP_INSPECTINPUTVALUE).
+		AddInt64(1).AddOp(arkade.OP_INSPECTINPUTVALUE).AddOp(arkade.OP_ADD).
+		AddInt64(p.topup).AddOp(arkade.OP_SUB).
+		AddOp(arkade.OP_EQUALVERIFY)
+
+	if p.assetID != nil {
+		appendAssetLookup(b, 1, p.assetID, true)
+		appendAssetLookup(b, 0, p.assetID, false)
+		appendAssetLookup(b, 1, p.assetID, false)
+		b.AddOp(arkade.OP_ADD).AddOp(arkade.OP_EQUAL)
+	}
+	return finishCovenant(t, b, p.assetID != nil)
+}
+
+// buildPurchaseCovenant pays the whole covenant to the receiver. The operator
+// recovers nothing here, having been compensated at lockup.
 func buildPurchaseCovenant(t *testing.T, p dustCovenantParams) []byte {
 	t.Helper()
 	b := txscript.NewScriptBuilder().
@@ -87,17 +162,39 @@ func buildPurchaseCovenant(t *testing.T, p dustCovenantParams) []byte {
 		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
 		AddInt64(0).AddOp(arkade.OP_INSPECTINPUTVALUE).AddOp(arkade.OP_EQUALVERIFY)
 
-	if p.assetID == nil {
-		b.AddOp(arkade.OP_1)
-	} else {
+	if p.assetID != nil {
 		appendAssetLookup(b, 0, p.assetID, true)
 		appendAssetLookup(b, 0, p.assetID, false)
 		b.AddOp(arkade.OP_EQUAL)
 	}
+	return finishCovenant(t, b, p.assetID != nil)
+}
 
-	s, err := b.Script()
-	require.NoError(t, err)
-	return s
+// buildRefundCovenant returns the payload to the sender and repays the operator.
+// Shared by the sender-signed refund leaf and the timelocked recovery leaf; the
+// sender's returned payload is a sub-dust receipt, which is acceptable because
+// the sender demonstrably owns a funded account and can merge it later.
+func buildRefundCovenant(t *testing.T, p dustCovenantParams, vtxoMinAmount int64) []byte {
+	t.Helper()
+	topup := p.refundTopup(vtxoMinAmount)
+	b := txscript.NewScriptBuilder().
+		AddOp(arkade.OP_PUSHCURRENTINPUTINDEX).AddInt64(0).AddOp(arkade.OP_EQUALVERIFY).
+		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddInt64(topup).AddOp(arkade.OP_EQUALVERIFY)
+
+	pinOutput(t, b, 0, p.operatorKey, topup, p.dust)
+
+	b.AddInt64(1).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
+		AddInt64(p.dust - topup).AddOp(arkade.OP_EQUALVERIFY)
+
+	pinOutput(t, b, 1, p.senderKey, p.dust-topup, p.dust)
+
+	if p.assetID != nil {
+		appendAssetLookup(b, 1, p.assetID, true)
+		appendAssetLookup(b, 0, p.assetID, false)
+		b.AddOp(arkade.OP_EQUAL)
+	}
+	return finishCovenant(t, b, p.assetID != nil)
 }
 
 func buildDustCovenantVtxoScript(
@@ -131,6 +228,103 @@ func tapscriptAt(t *testing.T, vtxoScript script.TapscriptsVtxoScript, i int) []
 	return s
 }
 
+type dustCovenantContract struct {
+	params   dustCovenantParams
+	recycle  []byte
+	purchase []byte
+	refund   []byte
+	vtxo     script.TapscriptsVtxoScript
+	pkScript []byte
+}
+
+func newDustCovenantContract(
+	t *testing.T, server, emulator, sender *btcec.PublicKey, p dustCovenantParams,
+) dustCovenantContract {
+	t.Helper()
+	recycle := buildRecycleCovenant(t, p)
+	purchase := buildPurchaseCovenant(t, p)
+	refund := buildRefundCovenant(t, p, dustCovenantVtxoMinAmount)
+	vtxo := buildDustCovenantVtxoScript(server, emulator, sender, p, recycle, purchase, refund)
+	return dustCovenantContract{
+		params:   p,
+		recycle:  recycle,
+		purchase: purchase,
+		refund:   refund,
+		vtxo:     vtxo,
+		pkScript: p2trScriptForVtxoScript(t, vtxo),
+	}
+}
+
+func (c dustCovenantContract) input(t *testing.T, prevTx *wire.MsgTx, leaf int) offchain.VtxoInput {
+	t.Helper()
+	return vtxoInputFromScriptOutput(t, prevTx, 0, c.vtxo, tapscriptAt(t, c.vtxo, leaf))
+}
+
+// issuancePacket mints a fresh asset, splitting it across the given outputs.
+// Outputs with a zero amount are omitted so the recipient genuinely holds no
+// entry for the asset, which is what exercises the lookup miss path.
+func issuancePacket(t *testing.T, amounts map[uint16]uint64) asset.Packet {
+	t.Helper()
+	outs := make([]asset.AssetOutput, 0, len(amounts))
+	for vout, amt := range amounts {
+		if amt == 0 {
+			continue
+		}
+		o, err := asset.NewAssetOutput(vout, amt)
+		require.NoError(t, err)
+		outs = append(outs, *o)
+	}
+	grp, err := asset.NewAssetGroup(nil, nil, []asset.AssetInput{}, outs, []asset.Metadata{})
+	require.NoError(t, err)
+	pkt, err := asset.NewPacket([]asset.AssetGroup{*grp})
+	require.NoError(t, err)
+	return pkt
+}
+
+// mergePacket moves the covenant's units at vin 0, plus whatever the receiver's
+// account already held at vin 1, into a single output at vout 1.
+func mergePacket(t *testing.T, id asset.AssetId, covenantUnits, accountUnits uint64) asset.Packet {
+	t.Helper()
+	in0, err := asset.NewAssetInput(0, covenantUnits)
+	require.NoError(t, err)
+	inputs := []asset.AssetInput{*in0}
+	if accountUnits > 0 {
+		in1, err := asset.NewAssetInput(1, accountUnits)
+		require.NoError(t, err)
+		inputs = append(inputs, *in1)
+	}
+	out, err := asset.NewAssetOutput(1, covenantUnits+accountUnits)
+	require.NoError(t, err)
+	grp, err := asset.NewAssetGroup(
+		&id, nil, inputs, []asset.AssetOutput{*out}, []asset.Metadata{},
+	)
+	require.NoError(t, err)
+	pkt, err := asset.NewPacket([]asset.AssetGroup{*grp})
+	require.NoError(t, err)
+	return pkt
+}
+
+// shortedPacket balances the group but diverts one unit away from the receiver,
+// so the covenant's sum clause sees out[1] one short of in[0] + in[1].
+func shortedPacket(t *testing.T, id asset.AssetId, units uint64) asset.Packet {
+	t.Helper()
+	require.Greater(t, units, uint64(1))
+	in, err := asset.NewAssetInput(0, units)
+	require.NoError(t, err)
+	diverted, err := asset.NewAssetOutput(0, 1)
+	require.NoError(t, err)
+	out, err := asset.NewAssetOutput(1, units-1)
+	require.NoError(t, err)
+	grp, err := asset.NewAssetGroup(
+		&id, nil, []asset.AssetInput{*in},
+		[]asset.AssetOutput{*diverted, *out}, []asset.Metadata{},
+	)
+	require.NoError(t, err)
+	pkt, err := asset.NewPacket([]asset.AssetGroup{*grp})
+	require.NoError(t, err)
+	return pkt
+}
+
 func TestDustCovenant(t *testing.T) {
 	ctx := t.Context()
 
@@ -142,9 +336,8 @@ func TestDustCovenant(t *testing.T) {
 	t.Cleanup(func() { grpcReceiver.Close() })
 	_ = fundAndSettleAlice(t, ctx, receiver, 100_000)
 
-	operator, operatorWallet, operatorPubKey, grpcOperator := setupArkSDKwithPublicKey(t)
+	_, _, operatorPubKey, grpcOperator := setupArkSDKwithPublicKey(t)
 	t.Cleanup(func() { grpcOperator.Close() })
-	_ = fundAndSettleAlice(t, ctx, operator, 100_000)
 
 	emulator, emulatorPubKey, conn := setupEmulatorClient(t, ctx)
 	t.Cleanup(func() { _ = conn.Close() })
@@ -161,20 +354,387 @@ func TestDustCovenant(t *testing.T) {
 	require.Greater(t, dust, dustCovenantVtxoMinAmount,
 		"sub-dust outputs need ARKD_VTXO_MIN_AMOUNT below dust")
 
-	_ = emulator
-	_ = senderWallet
-	_ = operatorWallet
-	_ = operator
-	_ = receiver
-	_ = indexerSvc
-	_ = checkpointScript
-	_ = server
-	_ = senderPubKey
-	_ = receiverPubKey
-	_ = operatorPubKey
-	_ = emulatorPubKey
+	exitDelay := uint32(infos.UnilateralExitDelay)
+	senderAccount := defaultVtxoScript(senderPubKey, server, exitDelay)
+	receiverAccount := defaultVtxoScript(receiverPubKey, server, exitDelay)
+	operatorAccount := defaultVtxoScript(operatorPubKey, server, exitDelay)
+
+	senderAccountPk := p2trScriptForVtxoScript(t, *senderAccount)
+	receiverAccountPk := p2trScriptForVtxoScript(t, *receiverAccount)
+
+	senderKey, _, err := senderAccount.TapTree()
+	require.NoError(t, err)
+	receiverKey, _, err := receiverAccount.TapTree()
+	require.NoError(t, err)
+	operatorKey, _, err := operatorAccount.TapTree()
+	require.NoError(t, err)
+
+	baseParams := func() dustCovenantParams {
+		return dustCovenantParams{
+			receiverKey: receiverKey,
+			senderKey:   senderKey,
+			operatorKey: operatorKey,
+			dust:        dust,
+			topup:       dust,
+			locktime:    dustCovenantLocktime,
+		}
+	}
+
+	// mint issues a fresh asset into the given outputs and returns the funding
+	// transaction plus its canonical AssetID. Issuance must happen in its own
+	// transaction: the covenant pins the AssetID, which for an issuance derives
+	// from that transaction's own txid.
+	mint := func(t *testing.T, outs []*wire.TxOut, amounts map[uint16]uint64) (*wire.MsgTx, asset.AssetId) {
+		t.Helper()
+		tx, cps := buildWalletFundedTx(
+			t, ctx, sender, indexerSvc, senderPubKey, server, exitDelay,
+			outs, checkpointScript,
+		)
+		addAssetPacketToTx(t, tx, issuancePacket(t, amounts))
+		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
+		h := tx.UnsignedTx.TxHash()
+		return tx.UnsignedTx, asset.AssetId{Txid: [asset.TX_HASH_SIZE]byte(h), Index: 0}
+	}
+
+	// lockup spends the sender's asset-bearing account into the covenant.
+	lockup := func(
+		t *testing.T, mintTx *wire.MsgTx, mintVout uint32, c dustCovenantContract, units uint64,
+	) *wire.MsgTx {
+		t.Helper()
+		in := vtxoInputFromScriptOutput(
+			t, mintTx, mintVout, *senderAccount, onlyForfeitScript(t, *senderAccount),
+		)
+		tx, cps, err := offchain.BuildTxs(
+			[]offchain.VtxoInput{in},
+			[]*wire.TxOut{{Value: c.params.dust, PkScript: c.pkScript}},
+			checkpointScript,
+		)
+		require.NoError(t, err)
+		if c.params.assetID != nil {
+			addAssetPacketToTx(t, tx, createTransferAssetPacket(
+				t, mintTx.TxHash(), 0, uint16(mintVout), 0, units,
+			))
+		}
+		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
+		return tx.UnsignedTx
+	}
+
+	submitToEmulator := func(t *testing.T, ptx *psbt.Packet, cps []*psbt.Packet) error {
+		t.Helper()
+		encoded, err := ptx.B64Encode()
+		require.NoError(t, err)
+		_, _, err = emulator.SubmitTx(ctx, encoded, encodeCheckpoints(t, cps))
+		return err
+	}
 
 	t.Run("purchase/valid", func(t *testing.T) {
-		t.Fatal("not implemented")
+		const units = uint64(100)
+
+		mintTx, assetID := mint(t,
+			[]*wire.TxOut{{Value: dust, PkScript: senderAccountPk}},
+			map[uint16]uint64{0: units},
+		)
+
+		p := baseParams()
+		p.assetID = &assetID
+		c := newDustCovenantContract(t, server, emulatorPubKey, senderPubKey, p)
+
+		lockTx := lockup(t, mintTx, 0, c, units)
+
+		claimTx, claimCps, err := offchain.BuildTxs(
+			[]offchain.VtxoInput{c.input(t, lockTx, leafPurchase)},
+			[]*wire.TxOut{{Value: dust, PkScript: receiverAccountPk}},
+			checkpointScript,
+		)
+		require.NoError(t, err)
+		addAssetPacketToTx(t, claimTx, createTransferAssetPacket(
+			t, lockTx.TxHash(), 0, 0, 0, units,
+		))
+		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{{Vin: 0, Script: c.purchase}})
+
+		require.NoError(t, executeArkadeScripts(t, claimTx, claimCps, emulatorPubKey))
+		require.NoError(t, submitToEmulator(t, claimTx, claimCps))
+	})
+
+	// recycleCase drives the merge path for a receiver holding priorUnits of the
+	// same asset. priorUnits == 0 exercises the (0, 0) miss return of
+	// OP_INSPECTINASSETLOOKUP, which is what lets one script serve both cases.
+	recycleCase := func(t *testing.T, priorUnits uint64) {
+		t.Helper()
+		const sent = uint64(1)
+
+		mintTx, assetID := mint(t,
+			[]*wire.TxOut{
+				{Value: dust, PkScript: senderAccountPk},
+				{Value: dust, PkScript: receiverAccountPk},
+			},
+			map[uint16]uint64{0: sent, 1: priorUnits},
+		)
+
+		p := baseParams()
+		p.assetID = &assetID
+		c := newDustCovenantContract(t, server, emulatorPubKey, senderPubKey, p)
+
+		lockTx := lockup(t, mintTx, 0, c, sent)
+
+		covenantIn := c.input(t, lockTx, leafRecycle)
+		accountIn := vtxoInputFromScriptOutput(
+			t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
+		)
+
+		merged := covenantIn.Amount + accountIn.Amount - p.topup
+		claimTx, claimCps, err := offchain.BuildTxs(
+			[]offchain.VtxoInput{covenantIn, accountIn},
+			[]*wire.TxOut{
+				{Value: p.topup, PkScript: payoutPkScript(t, operatorKey, p.topup, dust)},
+				{Value: merged, PkScript: receiverAccountPk},
+			},
+			checkpointScript,
+		)
+		require.NoError(t, err)
+		addAssetPacketToTx(t, claimTx, mergePacket(t, assetID, sent, priorUnits))
+		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{{Vin: 0, Script: c.recycle}})
+
+		require.NoError(t, executeArkadeScripts(t, claimTx, claimCps, emulatorPubKey))
+
+		require.Equal(t, accountIn.Amount, claimTx.UnsignedTx.TxOut[1].Value,
+			"receiver's bitcoin balance must be unchanged")
+		require.Equal(t, p.topup, claimTx.UnsignedTx.TxOut[0].Value,
+			"operator must recover its advance in full")
+	}
+
+	t.Run("recycle/receiver_holds_prior_balance", func(t *testing.T) {
+		recycleCase(t, 20)
+	})
+
+	t.Run("recycle/receiver_holds_zero", func(t *testing.T) {
+		recycleCase(t, 0)
+	})
+
+	// refundCase drives the shared refund covenant. leafRefundSender additionally
+	// requires the sender's signature, which the tapscript closure enforces
+	// rather than the covenant, so both leaves assert the same script.
+	refundCase := func(t *testing.T, leaf int) {
+		t.Helper()
+		const units = uint64(7)
+
+		mintTx, assetID := mint(t,
+			[]*wire.TxOut{{Value: dust, PkScript: senderAccountPk}},
+			map[uint16]uint64{0: units},
+		)
+
+		p := baseParams()
+		p.assetID = &assetID
+		c := newDustCovenantContract(t, server, emulatorPubKey, senderPubKey, p)
+
+		lockTx := lockup(t, mintTx, 0, c, units)
+		topup := p.refundTopup(dustCovenantVtxoMinAmount)
+
+		refundTx, refundCps, err := offchain.BuildTxs(
+			[]offchain.VtxoInput{c.input(t, lockTx, leaf)},
+			[]*wire.TxOut{
+				{Value: topup, PkScript: payoutPkScript(t, operatorKey, topup, dust)},
+				{Value: dust - topup, PkScript: payoutPkScript(t, senderKey, dust-topup, dust)},
+			},
+			checkpointScript,
+		)
+		require.NoError(t, err)
+		refundTx.UnsignedTx.LockTime = uint32(p.locktime)
+		addAssetPacketToTx(t, refundTx, createTransferAssetPacket(
+			t, lockTx.TxHash(), 0, 0, 1, units,
+		))
+		addEmulatorPacket(t, refundTx, []arkade.EmulatorEntry{{Vin: 0, Script: c.refund}})
+
+		require.NoError(t, executeArkadeScripts(t, refundTx, refundCps, emulatorPubKey))
+		require.Equal(t, dust-topup, refundTx.UnsignedTx.TxOut[1].Value,
+			"sender's returned payload must host the asset above vtxoMinAmount")
+	}
+
+	t.Run("refund/sender_signed", func(t *testing.T) {
+		refundCase(t, leafRefundSender)
+	})
+
+	t.Run("recovery/after_locktime", func(t *testing.T) {
+		refundCase(t, leafRecovery)
+	})
+
+	t.Run("bitcoin_variant/recycle_50_sats", func(t *testing.T) {
+		const payload = int64(50)
+
+		mintTx, _ := mint(t,
+			[]*wire.TxOut{
+				{Value: dust, PkScript: senderAccountPk},
+				{Value: dust, PkScript: receiverAccountPk},
+			},
+			map[uint16]uint64{0: 1},
+		)
+
+		p := baseParams()
+		p.topup = dust - payload
+		c := newDustCovenantContract(t, server, emulatorPubKey, senderPubKey, p)
+
+		lockTx := lockup(t, mintTx, 0, c, 0)
+
+		covenantIn := c.input(t, lockTx, leafRecycle)
+		accountIn := vtxoInputFromScriptOutput(
+			t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
+		)
+
+		merged := covenantIn.Amount + accountIn.Amount - p.topup
+		claimTx, claimCps, err := offchain.BuildTxs(
+			[]offchain.VtxoInput{covenantIn, accountIn},
+			[]*wire.TxOut{
+				{Value: p.topup, PkScript: payoutPkScript(t, operatorKey, p.topup, dust)},
+				{Value: merged, PkScript: receiverAccountPk},
+			},
+			checkpointScript,
+		)
+		require.NoError(t, err)
+		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{{Vin: 0, Script: c.recycle}})
+
+		require.NoError(t, executeArkadeScripts(t, claimTx, claimCps, emulatorPubKey))
+
+		require.Equal(t, payload, claimTx.UnsignedTx.TxOut[1].Value-accountIn.Amount,
+			"receiver must gain exactly the payload")
+		require.Equal(t, dust-payload, claimTx.UnsignedTx.TxOut[0].Value,
+			"operator must be made whole")
+	})
+
+	t.Run("reject", func(t *testing.T) {
+		const units = uint64(3)
+
+		mintTx, assetID := mint(t,
+			[]*wire.TxOut{
+				{Value: dust, PkScript: senderAccountPk},
+				{Value: dust, PkScript: receiverAccountPk},
+			},
+			map[uint16]uint64{0: units},
+		)
+
+		p := baseParams()
+		p.assetID = &assetID
+		c := newDustCovenantContract(t, server, emulatorPubKey, senderPubKey, p)
+
+		lockTx := lockup(t, mintTx, 0, c, units)
+
+		// buildRecycle produces a valid recycle spend, then applies a mutation.
+		// Each rejection case corrupts exactly one thing.
+		buildRecycle := func(
+			t *testing.T, mutate func(outs []*wire.TxOut, ins *[]offchain.VtxoInput),
+		) (*psbt.Packet, []*psbt.Packet) {
+			t.Helper()
+			covenantIn := c.input(t, lockTx, leafRecycle)
+			accountIn := vtxoInputFromScriptOutput(
+				t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
+			)
+			ins := []offchain.VtxoInput{covenantIn, accountIn}
+			outs := []*wire.TxOut{
+				{Value: p.topup, PkScript: payoutPkScript(t, operatorKey, p.topup, dust)},
+				{
+					Value:    covenantIn.Amount + accountIn.Amount - p.topup,
+					PkScript: receiverAccountPk,
+				},
+			}
+			mutate(outs, &ins)
+
+			tx, cps, err := offchain.BuildTxs(ins, outs, checkpointScript)
+			require.NoError(t, err)
+			addAssetPacketToTx(t, tx, mergePacket(t, assetID, units, 0))
+			addEmulatorPacket(t, tx, []arkade.EmulatorEntry{{Vin: 0, Script: c.recycle}})
+			return tx, cps
+		}
+
+		expectRejected := func(t *testing.T, ptx *psbt.Packet, cps []*psbt.Packet) {
+			t.Helper()
+			require.Error(t, executeArkadeScripts(t, ptx, cps, emulatorPubKey))
+			require.Error(t, submitToEmulator(t, ptx, cps))
+		}
+
+		t.Run("wrong_receiver", func(t *testing.T) {
+			tx, cps := buildRecycle(t, func(outs []*wire.TxOut, _ *[]offchain.VtxoInput) {
+				outs[1].PkScript = randomP2TRScript(t)
+			})
+			expectRejected(t, tx, cps)
+		})
+
+		t.Run("operator_underpaid", func(t *testing.T) {
+			tx, cps := buildRecycle(t, func(outs []*wire.TxOut, _ *[]offchain.VtxoInput) {
+				outs[0].Value--
+				outs[1].Value++
+			})
+			expectRejected(t, tx, cps)
+		})
+
+		t.Run("extra_input", func(t *testing.T) {
+			tx, cps := buildRecycle(t, func(_ []*wire.TxOut, ins *[]offchain.VtxoInput) {
+				extra := vtxoInputFromScriptOutput(
+					t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
+				)
+				*ins = append(*ins, extra)
+			})
+			expectRejected(t, tx, cps)
+		})
+
+		t.Run("wrong_account_at_input_one", func(t *testing.T) {
+			tx, cps := buildRecycle(t, func(_ []*wire.TxOut, ins *[]offchain.VtxoInput) {
+				(*ins)[1] = vtxoInputFromScriptOutput(
+					t, mintTx, 0, *senderAccount, onlyForfeitScript(t, *senderAccount),
+				)
+			})
+			expectRejected(t, tx, cps)
+		})
+
+		// Shorting the pinned asset is the substitution case the covenant can
+		// actually catch. Swapping in a foreign AssetID instead makes all three
+		// lookups miss, so the clause degenerates to 0 == 0 + 0 and passes; what
+		// rejects that spend is arkd's asset-balance validation, which sees the
+		// covenant's asset entering with no matching group. Substitution safety
+		// is a property of the covenant and arkd together, not the covenant alone.
+		t.Run("asset_amount_shorted", func(t *testing.T) {
+			covenantIn := c.input(t, lockTx, leafRecycle)
+			accountIn := vtxoInputFromScriptOutput(
+				t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
+			)
+			tx, cps, err := offchain.BuildTxs(
+				[]offchain.VtxoInput{covenantIn, accountIn},
+				[]*wire.TxOut{
+					{Value: p.topup, PkScript: payoutPkScript(t, operatorKey, p.topup, dust)},
+					{
+						Value:    covenantIn.Amount + accountIn.Amount - p.topup,
+						PkScript: receiverAccountPk,
+					},
+				},
+				checkpointScript,
+			)
+			require.NoError(t, err)
+			addAssetPacketToTx(t, tx, shortedPacket(t, assetID, units))
+			addEmulatorPacket(t, tx, []arkade.EmulatorEntry{{Vin: 0, Script: c.recycle}})
+			expectRejected(t, tx, cps)
+		})
+
+		t.Run("recovery_before_locktime", func(t *testing.T) {
+			topup := p.refundTopup(dustCovenantVtxoMinAmount)
+			tx, cps, err := offchain.BuildTxs(
+				[]offchain.VtxoInput{c.input(t, lockTx, leafRecovery)},
+				[]*wire.TxOut{
+					{Value: topup, PkScript: payoutPkScript(t, operatorKey, topup, dust)},
+					{
+						Value:    dust - topup,
+						PkScript: payoutPkScript(t, senderKey, dust-topup, dust),
+					},
+				},
+				checkpointScript,
+			)
+			require.NoError(t, err)
+			tx.UnsignedTx.LockTime = uint32(p.locktime) - 1
+			addAssetPacketToTx(t, tx, createTransferAssetPacket(
+				t, lockTx.TxHash(), 0, 0, 1, units,
+			))
+			addEmulatorPacket(t, tx, []arkade.EmulatorEntry{{Vin: 0, Script: c.refund}})
+
+			// The covenant itself does not read the locktime; the CLTV closure
+			// does. Only the live emulator can reject this.
+			require.Error(t, submitToEmulator(t, tx, cps))
+		})
 	})
 }

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -2,7 +2,9 @@ package test
 
 import (
 	"encoding/hex"
+	"sort"
 	"testing"
+	"time"
 
 	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
@@ -70,11 +72,19 @@ func (c dustContract) payout(t *testing.T, key *btcec.PublicKey, value int64) []
 }
 
 // issuancePacket mints a fresh asset across the given outputs. Zero amounts are
-// omitted, so a recipient genuinely holds no entry for the asset.
+// omitted, so a recipient genuinely holds no entry for the asset. Outputs are
+// emitted in vout order: ranging a map directly would randomise it between runs.
 func issuancePacket(t *testing.T, amounts map[uint16]uint64) asset.Packet {
 	t.Helper()
+	vouts := make([]uint16, 0, len(amounts))
+	for vout := range amounts {
+		vouts = append(vouts, vout)
+	}
+	sort.Slice(vouts, func(i, j int) bool { return vouts[i] < vouts[j] })
+
 	outs := make([]asset.AssetOutput, 0, len(amounts))
-	for vout, amt := range amounts {
+	for _, vout := range vouts {
+		amt := amounts[vout]
 		if amt == 0 {
 			continue
 		}
@@ -178,6 +188,21 @@ func TestDustCovenant(t *testing.T) {
 		}
 	}
 
+	// arkd registers a submitted transaction's outputs asynchronously, so
+	// spending one immediately can lose the race and fail with VTXO_NOT_FOUND.
+	// Polling the indexer for the transaction is used rather than the
+	// subscription helper: a subscription opened per funding transaction, over
+	// scripts an earlier subscription had already registered and removed, did not
+	// deliver its events (got 0/3) even though the transaction was accepted.
+	awaitIndexed := func(t *testing.T, tx *wire.MsgTx) {
+		t.Helper()
+		txid := tx.TxID()
+		require.Eventually(t, func() bool {
+			res, err := indexerSvc.GetVirtualTxs(ctx, []string{txid})
+			return err == nil && len(res.Txs) == 1
+		}, 30*time.Second, 250*time.Millisecond, "tx %s never indexed", txid)
+	}
+
 	funderAccount := defaultVtxoScript(funderPubKey, server, exitDelay)
 	funderAccountPk := p2trScriptForVtxoScript(t, *funderAccount)
 
@@ -211,12 +236,8 @@ func TestDustCovenant(t *testing.T) {
 			addAssetPacketToTx(t, tx, *packet)
 		}
 
-		// arkd registers the new VTXOs asynchronously; spending one before it is
-		// observable fails with VTXO_NOT_FOUND. The subscription must be opened
-		// before submitting, and after the outputs are final.
-		confirmed := watchForPreconfirmedVtxos(t, indexerSvc, tx, 0, 1, 2)
 		submitWithArkd(t, ctx, tx, cps, funderWallet, grpcFunder)
-		confirmed()
+		awaitIndexed(t, tx.UnsignedTx)
 
 		funderFunding = vtxoInputFromScriptOutput(
 			t, tx.UnsignedTx, 2, *funderAccount, onlyForfeitScript(t, *funderAccount),
@@ -266,9 +287,8 @@ func TestDustCovenant(t *testing.T) {
 			))
 		}
 
-		confirmed := watchForPreconfirmedVtxos(t, indexerSvc, tx, 0)
 		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
-		confirmed()
+		awaitIndexed(t, tx.UnsignedTx)
 
 		return tx.UnsignedTx
 	}

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -167,40 +167,73 @@ func TestDustCovenant(t *testing.T) {
 		}
 	}
 
-	// mint issues a fresh asset into the given outputs. Issuance must happen in
-	// its own transaction: the covenant pins the AssetID, which for an issuance
-	// derives from that transaction's own txid, so issuing inside the lockup
-	// would make the address depend on a txid that depends on the address.
+	// senderVout is where buildWalletFundedTx puts the sender's change: it is
+	// appended after the outputs we ask for. The sender's share of a mint rides
+	// on that change output rather than on an output of its own, because
+	// buildWalletFundedTx sends change to the sender's account script -- the same
+	// script -- and findTaprootOutput picks the first output matching it. Two
+	// outputs with that script make the next call resolve the wrong index
+	// (utils_test.go:560).
+	const senderVout = uint32(1)
+
+	// fundAccounts gives the receiver a dust account and leaves the rest as the
+	// sender's change. No asset packet.
+	fundAccounts := func(t *testing.T) *wire.MsgTx {
+		t.Helper()
+		tx, cps := buildWalletFundedTx(
+			t, ctx, sender, indexerSvc, senderPubKey, server, exitDelay,
+			[]*wire.TxOut{{Value: dust, PkScript: receiverAccountPk}}, checkpointScript,
+		)
+		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
+		return tx.UnsignedTx
+	}
+
+	// mint does the same and issues an asset across both outputs. Issuance must
+	// happen in its own transaction: the covenant pins the AssetID, which for an
+	// issuance derives from that transaction's own txid, so issuing inside the
+	// lockup would make the address depend on a txid that depends on the address.
 	mint := func(
-		t *testing.T, outs []*wire.TxOut, amounts map[uint16]uint64,
+		t *testing.T, receiverUnits, senderUnits uint64,
 	) (*wire.MsgTx, asset.AssetId) {
 		t.Helper()
 		tx, cps := buildWalletFundedTx(
 			t, ctx, sender, indexerSvc, senderPubKey, server, exitDelay,
-			outs, checkpointScript,
+			[]*wire.TxOut{{Value: dust, PkScript: receiverAccountPk}}, checkpointScript,
 		)
-		addAssetPacketToTx(t, tx, issuancePacket(t, amounts))
+		addAssetPacketToTx(t, tx, issuancePacket(t, map[uint16]uint64{
+			0:                  receiverUnits,
+			uint16(senderVout): senderUnits,
+		}))
 		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
 		h := tx.UnsignedTx.TxHash()
 		return tx.UnsignedTx, asset.AssetId{Txid: [asset.TX_HASH_SIZE]byte(h), Index: 0}
 	}
 
+	// lockup spends the sender's change into the covenant, returning the balance
+	// as fresh change so the sender's bitcoin is not burned as fee.
 	lockup := func(
-		t *testing.T, mintTx *wire.MsgTx, mintVout uint32, c dustContract, units uint64,
+		t *testing.T, mintTx *wire.MsgTx, c dustContract, units uint64,
 	) *wire.MsgTx {
 		t.Helper()
 		in := vtxoInputFromScriptOutput(
-			t, mintTx, mintVout, *senderAccount, onlyForfeitScript(t, *senderAccount),
+			t, mintTx, senderVout, *senderAccount, onlyForfeitScript(t, *senderAccount),
 		)
+		change := in.Amount - c.params.Dust
+		require.Positive(t, change)
+
 		tx, cps, err := offchain.BuildTxs(
 			[]offchain.VtxoInput{in},
-			[]*wire.TxOut{{Value: c.params.Dust, PkScript: c.pkScript}},
+			[]*wire.TxOut{
+				{Value: c.params.Dust, PkScript: c.pkScript},
+				{Value: change, PkScript: senderAccountPk},
+			},
 			checkpointScript,
 		)
 		require.NoError(t, err)
 		if c.params.AssetID != nil {
+			// vin is the transaction input index, not the mint's output index.
 			addAssetPacketToTx(t, tx, createTransferAssetPacket(
-				t, mintTx.TxHash(), 0, uint16(mintVout), 0, units,
+				t, mintTx.TxHash(), 0, 0, 0, units,
 			))
 		}
 		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
@@ -218,16 +251,13 @@ func TestDustCovenant(t *testing.T) {
 	t.Run("purchase", func(t *testing.T) {
 		const units = uint64(100)
 
-		mintTx, assetID := mint(t,
-			[]*wire.TxOut{{Value: dust, PkScript: senderAccountPk}},
-			map[uint16]uint64{0: units},
-		)
+		mintTx, assetID := mint(t, 0, units)
 
 		p := baseParams()
 		p.AssetID = &assetID
 		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
-		lockTx := lockup(t, mintTx, 0, c, units)
+		lockTx := lockup(t, mintTx, c, units)
 
 		claimTx, claimCps, err := offchain.BuildTxs(
 			[]offchain.VtxoInput{c.input(t, lockTx, covenant.LeafPurchase)},
@@ -235,8 +265,10 @@ func TestDustCovenant(t *testing.T) {
 			checkpointScript,
 		)
 		require.NoError(t, err)
+		// The AssetID stays the issuance txid for the asset's whole life; it does
+		// not become the lockup's txid when the asset moves.
 		addAssetPacketToTx(t, claimTx, createTransferAssetPacket(
-			t, lockTx.TxHash(), 0, 0, 0, units,
+			t, mintTx.TxHash(), 0, 0, 0, units,
 		))
 		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{
 			{Vin: 0, Script: c.scripts.Purchase},
@@ -252,23 +284,17 @@ func TestDustCovenant(t *testing.T) {
 		t.Helper()
 		const sent = uint64(1)
 
-		mintTx, assetID := mint(t,
-			[]*wire.TxOut{
-				{Value: dust, PkScript: senderAccountPk},
-				{Value: dust, PkScript: receiverAccountPk},
-			},
-			map[uint16]uint64{0: sent, 1: priorUnits},
-		)
+		mintTx, assetID := mint(t, priorUnits, sent)
 
 		p := baseParams()
 		p.AssetID = &assetID
 		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
-		lockTx := lockup(t, mintTx, 0, c, sent)
+		lockTx := lockup(t, mintTx, c, sent)
 
 		covenantIn := c.input(t, lockTx, covenant.LeafRecycle)
 		accountIn := vtxoInputFromScriptOutput(
-			t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
+			t, mintTx, 0, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
 		)
 
 		merged := covenantIn.Amount + accountIn.Amount - p.Topup
@@ -306,16 +332,13 @@ func TestDustCovenant(t *testing.T) {
 	t.Run("recovery/after_locktime", func(t *testing.T) {
 		const units = uint64(7)
 
-		mintTx, assetID := mint(t,
-			[]*wire.TxOut{{Value: dust, PkScript: senderAccountPk}},
-			map[uint16]uint64{0: units},
-		)
+		mintTx, assetID := mint(t, 0, units)
 
 		p := baseParams()
 		p.AssetID = &assetID
 		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
-		lockTx := lockup(t, mintTx, 0, c, units)
+		lockTx := lockup(t, mintTx, c, units)
 		topup := p.RefundTopup(dustCovenantVtxoMinAmount)
 
 		refundTx, refundCps, err := offchain.BuildTxs(
@@ -329,7 +352,7 @@ func TestDustCovenant(t *testing.T) {
 		require.NoError(t, err)
 		refundTx.UnsignedTx.LockTime = uint32(p.Locktime)
 		addAssetPacketToTx(t, refundTx, createTransferAssetPacket(
-			t, lockTx.TxHash(), 0, 0, 1, units,
+			t, mintTx.TxHash(), 0, 0, 1, units,
 		))
 		addEmulatorPacket(t, refundTx, []arkade.EmulatorEntry{
 			{Vin: 0, Script: c.scripts.Refund},
@@ -345,16 +368,13 @@ func TestDustCovenant(t *testing.T) {
 	t.Run("recovery/rejected_before_locktime", func(t *testing.T) {
 		const units = uint64(7)
 
-		mintTx, assetID := mint(t,
-			[]*wire.TxOut{{Value: dust, PkScript: senderAccountPk}},
-			map[uint16]uint64{0: units},
-		)
+		mintTx, assetID := mint(t, 0, units)
 
 		p := baseParams()
 		p.AssetID = &assetID
 		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
-		lockTx := lockup(t, mintTx, 0, c, units)
+		lockTx := lockup(t, mintTx, c, units)
 		topup := p.RefundTopup(dustCovenantVtxoMinAmount)
 
 		tx, cps, err := offchain.BuildTxs(
@@ -368,33 +388,33 @@ func TestDustCovenant(t *testing.T) {
 		require.NoError(t, err)
 		tx.UnsignedTx.LockTime = uint32(p.Locktime) - 1
 		addAssetPacketToTx(t, tx, createTransferAssetPacket(
-			t, lockTx.TxHash(), 0, 0, 1, units,
+			t, mintTx.TxHash(), 0, 0, 1, units,
 		))
 		addEmulatorPacket(t, tx, []arkade.EmulatorEntry{{Vin: 0, Script: c.scripts.Refund}})
 
+		// Asserting the covenant accepts first is what makes the rejection
+		// meaningful: it isolates the failure to the CLTV closure rather than
+		// letting the test pass for any unrelated reason.
+		require.NoError(t, executeArkadeScripts(t, tx, cps, emulatorPubKey))
 		require.Error(t, submitToEmulator(t, tx, cps))
 	})
 
 	t.Run("bitcoin_variant/recycle_50_sats", func(t *testing.T) {
 		const payload = int64(50)
 
-		mintTx, _ := mint(t,
-			[]*wire.TxOut{
-				{Value: dust, PkScript: senderAccountPk},
-				{Value: dust, PkScript: receiverAccountPk},
-			},
-			map[uint16]uint64{0: 1},
-		)
+		// No asset anywhere: the bitcoin variant omits the asset clauses, and an
+		// unaccounted asset on the input would be rejected by arkd.
+		fundTx := fundAccounts(t)
 
 		p := baseParams()
 		p.Topup = dust - payload
 		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
-		lockTx := lockup(t, mintTx, 0, c, 0)
+		lockTx := lockup(t, fundTx, c, 0)
 
 		covenantIn := c.input(t, lockTx, covenant.LeafRecycle)
 		accountIn := vtxoInputFromScriptOutput(
-			t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
+			t, fundTx, 0, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
 		)
 
 		merged := covenantIn.Amount + accountIn.Amount - p.Topup

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -373,6 +373,18 @@ func TestDustCovenant(t *testing.T) {
 		return err
 	}
 
+	// LeafRefundSender's closure carries the sender's key, so the sender signs the
+	// arkade transaction and its checkpoints alongside the emulator.
+	submitSenderSigned := func(t *testing.T, ptx *psbt.Packet, cps []*psbt.Packet) error {
+		t.Helper()
+		signed, err := senderWallet.SignTransaction(ctx, b64(t, ptx), nil)
+		require.NoError(t, err)
+		_, _, err = emulator.SubmitTx(
+			ctx, signed, signCheckpoints(t, ctx, senderWallet, nil, cps),
+		)
+		return err
+	}
+
 	// A merge also spends the receiver's own account, so the receiver must sign
 	// the arkade transaction and its checkpoints. The emulator supplies only the
 	// covenant input's signature.
@@ -497,8 +509,51 @@ func TestDustCovenant(t *testing.T) {
 			{Vin: 0, Script: c.scripts.Refund},
 		})
 
+		// arkd accepting this transaction is what validates the hardcoded
+		// vtxoMinAmount: the sender's returned payload is exactly that many sats,
+		// and a lower configured minimum would reject it.
+		require.Equal(t, dustCovenantVtxoMinAmount, dust-topup,
+			"refund reserves exactly one vtxoMinAmount for the sender's payload")
+
 		require.NoError(t, executeArkadeScripts(t, refundTx, refundCps, emulatorPubKey))
 		require.NoError(t, submitToEmulator(t, refundTx, refundCps))
+	})
+
+	// LeafRefundSender is the only leaf carrying a human key. It shares the refund
+	// covenant with LeafRecovery but not its closure, so the end-to-end path --
+	// sender signs, emulator signs, arkd accepts -- needs its own coverage.
+	t.Run("refund/sender_signed", func(t *testing.T) {
+		const units = uint64(7)
+
+		mintTx, assetID := mint(t, units)
+
+		p := baseParams()
+		p.AssetID = &assetID
+		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
+
+		lockTx := lockup(t, mintTx, c, units, 0)
+		topup := p.RefundTopup(dustCovenantVtxoMinAmount)
+
+		refundTx, refundCps, err := offchain.BuildTxs(
+			[]offchain.VtxoInput{c.input(t, lockTx, covenant.LeafRefundSender)},
+			[]*wire.TxOut{
+				{Value: topup, PkScript: c.payout(t, operatorKey, topup)},
+				{Value: dust - topup, PkScript: c.payout(t, senderKey, dust-topup)},
+			},
+			checkpointScript,
+		)
+		require.NoError(t, err)
+		addAssetPacketToTx(t, refundTx, createTransferAssetPacket(
+			t, mintTx.TxHash(), 0, 0, 1, units,
+		))
+		addEmulatorPacket(t, refundTx, []arkade.EmulatorEntry{
+			{Vin: 0, Script: c.scripts.Refund},
+		})
+
+		// No locktime is set: unlike recovery, this leaf is spendable immediately
+		// because the sender's signature stands in for the timeout.
+		require.NoError(t, executeArkadeScripts(t, refundTx, refundCps, emulatorPubKey))
+		require.NoError(t, submitSenderSigned(t, refundTx, refundCps))
 	})
 
 	// The covenant does not read the locktime; the CLTV closure does. Only a live

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -102,6 +102,39 @@ func issuancePacket(t *testing.T, amounts map[uint16]uint64) asset.Packet {
 	return pkt
 }
 
+// transferPacket moves an existing asset from vin 0 across the given outputs.
+// Multi-output transfers are fine, unlike multi-output issuance; the
+// asset-account prototype's routing packet splits across three.
+func transferPacket(
+	t *testing.T, id asset.AssetId, total uint64, amounts map[uint16]uint64,
+) asset.Packet {
+	t.Helper()
+	in, err := asset.NewAssetInput(0, total)
+	require.NoError(t, err)
+
+	vouts := make([]uint16, 0, len(amounts))
+	for vout := range amounts {
+		vouts = append(vouts, vout)
+	}
+	sort.Slice(vouts, func(i, j int) bool { return vouts[i] < vouts[j] })
+
+	outs := make([]asset.AssetOutput, 0, len(amounts))
+	for _, vout := range vouts {
+		if amounts[vout] == 0 {
+			continue
+		}
+		o, err := asset.NewAssetOutput(vout, amounts[vout])
+		require.NoError(t, err)
+		outs = append(outs, *o)
+	}
+
+	grp, err := asset.NewAssetGroup(&id, nil, []asset.AssetInput{*in}, outs, []asset.Metadata{})
+	require.NoError(t, err)
+	pkt, err := asset.NewPacket([]asset.AssetGroup{*grp})
+	require.NoError(t, err)
+	return pkt
+}
+
 // setPrevArkTxs attaches each input's previous arkade transaction. This is not
 // automatic: executeArkadeScripts and the emulator skip inputs without the
 // field, so FetchVtxoPrevOutPkScript returns nil and OP_INSPECTINPUTSCRIPTPUBKEY
@@ -234,9 +267,11 @@ func TestDustCovenant(t *testing.T) {
 	// Outputs, each with a distinct script -- two outputs sharing one script make
 	// the wallet sign for the wrong prevout amount:
 	//
-	//	[0] receiver account, dust
-	//	[1] sender account, dust, carrying the sender's asset
-	//	[2] funder change, unused
+	//	[0] sender account, two dust units, carrying the whole issuance
+	//	[1] funder change, unused
+	//
+	// The sender gets two dust units because the lockup splits this account into
+	// the covenant and the receiver's account, and each needs one.
 	fundAccounts := func(t *testing.T, packet *asset.Packet) *wire.MsgTx {
 		t.Helper()
 
@@ -254,8 +289,7 @@ func TestDustCovenant(t *testing.T) {
 		tx, cps, err := offchain.BuildTxs(
 			[]offchain.VtxoInput{funding},
 			[]*wire.TxOut{
-				{Value: dust, PkScript: receiverAccountPk},
-				{Value: dust, PkScript: senderAccountPk},
+				{Value: 2 * dust, PkScript: senderAccountPk},
 				{Value: change, PkScript: funderAccountPk},
 			},
 			checkpointScript,
@@ -266,55 +300,65 @@ func TestDustCovenant(t *testing.T) {
 		}
 
 		submitWithArkd(t, ctx, tx, cps, funderWallet, grpcFunder)
-		awaitSpendable(t, tx.UnsignedTx, 0, 1)
+		awaitSpendable(t, tx.UnsignedTx, 0)
 
 		return tx.UnsignedTx
 	}
 
-	// mint issues a fresh asset. Issuance must happen in its own transaction: the
-	// covenant pins the AssetID, which for an issuance derives from that
-	// transaction's own txid, so issuing inside the lockup would make the address
-	// depend on a txid that depends on the address.
-	mint := func(
-		t *testing.T, receiverUnits, senderUnits uint64,
-	) (*wire.MsgTx, asset.AssetId) {
+	// mint issues a fresh asset to a single output. Issuance must happen in its
+	// own transaction: the covenant pins the AssetID, which for an issuance
+	// derives from that transaction's own txid, so issuing inside the lockup
+	// would make the address depend on a txid that depends on the address.
+	//
+	// Single-output deliberately. A two-output issuance made the funding
+	// transaction fail to finalize with an invalid checkpoint signature, while
+	// multi-output *transfers* are fine -- the asset-account prototype's routing
+	// packet splits across three. So the split happens in the lockup instead.
+	mint := func(t *testing.T, units uint64) (*wire.MsgTx, asset.AssetId) {
 		t.Helper()
-		amounts := map[uint16]uint64{1: senderUnits}
-		if receiverUnits > 0 {
-			amounts[0] = receiverUnits
-		}
-		packet := issuancePacket(t, amounts)
+		packet := issuancePacket(t, map[uint16]uint64{0: units})
 		tx := fundAccounts(t, &packet)
 		h := tx.TxHash()
 		return tx, asset.AssetId{Txid: [asset.TX_HASH_SIZE]byte(h), Index: 0}
 	}
 
-	// lockup spends the sender's whole dust account into the covenant, so there is
-	// no change and the sender's bitcoin commitment stays at exactly one dust unit.
+	// lockup splits the sender's funded account into the covenant and the
+	// receiver's account, in one transfer:
+	//
+	//	[0] covenant, dust, carrying sent units
+	//	[1] receiver account, dust, carrying priorUnits (its balance before the
+	//	    payment, which the recycle covenant must tolerate at any value)
+	//
+	// Doing the split here rather than at issuance is what keeps the issuance
+	// single-output; see mint. The sender's own bitcoin commitment is unchanged
+	// either way, since both dust units came from the funder.
 	lockup := func(
-		t *testing.T, fundTx *wire.MsgTx, c dustContract, units uint64,
+		t *testing.T, fundTx *wire.MsgTx, c dustContract, sent, priorUnits uint64,
 	) *wire.MsgTx {
 		t.Helper()
 		in := vtxoInputFromScriptOutput(
-			t, fundTx, 1, *senderAccount, onlyForfeitScript(t, *senderAccount),
+			t, fundTx, 0, *senderAccount, onlyForfeitScript(t, *senderAccount),
 		)
-		require.Equal(t, c.params.Dust, in.Amount)
+		require.Equal(t, 2*c.params.Dust, in.Amount)
 
 		tx, cps, err := offchain.BuildTxs(
 			[]offchain.VtxoInput{in},
-			[]*wire.TxOut{{Value: c.params.Dust, PkScript: c.pkScript}},
+			[]*wire.TxOut{
+				{Value: c.params.Dust, PkScript: c.pkScript},
+				{Value: c.params.Dust, PkScript: receiverAccountPk},
+			},
 			checkpointScript,
 		)
 		require.NoError(t, err)
 		if c.params.AssetID != nil {
 			// vin is the transaction input index, not the funding output index.
-			addAssetPacketToTx(t, tx, createTransferAssetPacket(
-				t, fundTx.TxHash(), 0, 0, 0, units,
+			addAssetPacketToTx(t, tx, transferPacket(t, *c.params.AssetID,
+				sent+priorUnits, map[uint16]uint64{0: sent, 1: priorUnits},
 			))
 		}
 
 		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
-		awaitSpendable(t, tx.UnsignedTx, 0)
+		awaitSpendable(t, tx.UnsignedTx, 0, 1)
 
 		return tx.UnsignedTx
 	}
@@ -345,13 +389,13 @@ func TestDustCovenant(t *testing.T) {
 	t.Run("purchase", func(t *testing.T) {
 		const units = uint64(100)
 
-		mintTx, assetID := mint(t, 0, units)
+		mintTx, assetID := mint(t, units)
 
 		p := baseParams()
 		p.AssetID = &assetID
 		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
-		lockTx := lockup(t, mintTx, c, units)
+		lockTx := lockup(t, mintTx, c, units, 0)
 
 		claimTx, claimCps, err := offchain.BuildTxs(
 			[]offchain.VtxoInput{c.input(t, lockTx, covenant.LeafPurchase)},
@@ -378,17 +422,17 @@ func TestDustCovenant(t *testing.T) {
 		t.Helper()
 		const sent = uint64(1)
 
-		mintTx, assetID := mint(t, priorUnits, sent)
+		mintTx, assetID := mint(t, sent+priorUnits)
 
 		p := baseParams()
 		p.AssetID = &assetID
 		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
-		lockTx := lockup(t, mintTx, c, sent)
+		lockTx := lockup(t, mintTx, c, sent, priorUnits)
 
 		covenantIn := c.input(t, lockTx, covenant.LeafRecycle)
 		accountIn := vtxoInputFromScriptOutput(
-			t, mintTx, 0, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
+			t, lockTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
 		)
 
 		merged := covenantIn.Amount + accountIn.Amount - p.Topup
@@ -402,7 +446,7 @@ func TestDustCovenant(t *testing.T) {
 		)
 		require.NoError(t, err)
 		addAssetPacketToTx(t, claimTx, mergePacket(t, assetID, sent, priorUnits))
-		setPrevArkTxs(t, claimTx, lockTx, mintTx)
+		setPrevArkTxs(t, claimTx, lockTx, lockTx)
 		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{
 			{Vin: 0, Script: c.scripts.Recycle},
 		})
@@ -427,13 +471,13 @@ func TestDustCovenant(t *testing.T) {
 	t.Run("recovery/after_locktime", func(t *testing.T) {
 		const units = uint64(7)
 
-		mintTx, assetID := mint(t, 0, units)
+		mintTx, assetID := mint(t, units)
 
 		p := baseParams()
 		p.AssetID = &assetID
 		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
-		lockTx := lockup(t, mintTx, c, units)
+		lockTx := lockup(t, mintTx, c, units, 0)
 		topup := p.RefundTopup(dustCovenantVtxoMinAmount)
 
 		refundTx, refundCps, err := offchain.BuildTxs(
@@ -463,13 +507,13 @@ func TestDustCovenant(t *testing.T) {
 	t.Run("recovery/rejected_before_locktime", func(t *testing.T) {
 		const units = uint64(7)
 
-		mintTx, assetID := mint(t, 0, units)
+		mintTx, assetID := mint(t, units)
 
 		p := baseParams()
 		p.AssetID = &assetID
 		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
-		lockTx := lockup(t, mintTx, c, units)
+		lockTx := lockup(t, mintTx, c, units, 0)
 		topup := p.RefundTopup(dustCovenantVtxoMinAmount)
 
 		tx, cps, err := offchain.BuildTxs(
@@ -505,11 +549,11 @@ func TestDustCovenant(t *testing.T) {
 		p.Topup = dust - payload
 		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
-		lockTx := lockup(t, fundTx, c, 0)
+		lockTx := lockup(t, fundTx, c, 0, 0)
 
 		covenantIn := c.input(t, lockTx, covenant.LeafRecycle)
 		accountIn := vtxoInputFromScriptOutput(
-			t, fundTx, 0, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
+			t, lockTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
 		)
 
 		merged := covenantIn.Amount + accountIn.Amount - p.Topup
@@ -522,7 +566,7 @@ func TestDustCovenant(t *testing.T) {
 			checkpointScript,
 		)
 		require.NoError(t, err)
-		setPrevArkTxs(t, claimTx, lockTx, fundTx)
+		setPrevArkTxs(t, claimTx, lockTx, lockTx)
 		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{
 			{Vin: 0, Script: c.scripts.Recycle},
 		})

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -509,11 +509,12 @@ func TestDustCovenant(t *testing.T) {
 			{Vin: 0, Script: c.scripts.Refund},
 		})
 
-		// arkd accepting this transaction is what validates the hardcoded
-		// vtxoMinAmount: the sender's returned payload is exactly that many sats,
-		// and a lower configured minimum would reject it.
-		require.Equal(t, dustCovenantVtxoMinAmount, dust-topup,
-			"refund reserves exactly one vtxoMinAmount for the sender's payload")
+		// The live validation of the hardcoded vtxoMinAmount is arkd accepting this
+		// transaction: the sender's returned payload is exactly that many sats, so
+		// a higher configured minimum rejects it. Asserting dust-topup ==
+		// dustCovenantVtxoMinAmount here would prove nothing, being true by
+		// construction once RefundTopup has been applied.
+		require.Less(t, dust-topup, dust, "sender's payload must be sub-dust")
 
 		require.NoError(t, executeArkadeScripts(t, refundTx, refundCps, emulatorPubKey))
 		require.NoError(t, submitToEmulator(t, refundTx, refundCps))

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -138,17 +138,6 @@ func TestDustCovenant(t *testing.T) {
 	_, _, operatorPubKey, grpcOperator := setupArkSDKwithPublicKey(t)
 	t.Cleanup(func() { grpcOperator.Close() })
 
-	// A separate identity pays for every funding transaction. Sighash commits to
-	// the prevout amount, and the wallet resolves an input by script, so two
-	// outputs sharing a script in one transaction make it sign for the wrong
-	// amount and produce an invalid checkpoint signature. The sender's account
-	// script is the only one their wallet can sign, so the sender cannot both
-	// hold a dust output and take change. A funder gives every output in a
-	// funding transaction a distinct script.
-	funder, funderWallet, funderPubKey, grpcFunder := setupArkSDKwithPublicKey(t)
-	t.Cleanup(func() { grpcFunder.Close() })
-	_ = fundAndSettleAlice(t, ctx, funder, 200_000)
-
 	emulator, emulatorPubKey, conn := setupEmulatorClient(t, ctx)
 	t.Cleanup(func() { _ = conn.Close() })
 
@@ -220,27 +209,35 @@ func TestDustCovenant(t *testing.T) {
 		}, 30*time.Second, 250*time.Millisecond, "vtxos of %s not spendable", txid)
 	}
 
-	funderAccount := defaultVtxoScript(funderPubKey, server, exitDelay)
-	funderAccountPk := p2trScriptForVtxoScript(t, *funderAccount)
-
-	// submitWithArkd goes straight to arkd, so the SDK's ListVtxos never learns
-	// the VTXO was spent and buildWalletFundedTx keeps handing back inputs this
-	// test already consumed. The funder's VTXO is resolved once and threaded by
-	// hand. Every funding transaction lays its outputs out the same way, each
-	// with a distinct script:
+	// Each funding transaction uses its own freshly settled funder and is never
+	// chained into the next. Spending a settled VTXO works; spending a funder's
+	// change from a previous arkade transaction produced an invalid signature in
+	// the checkpoint, and the asset-account prototype likewise funds once and
+	// only ever spends that transaction's first output. A funder per call also
+	// removes the cross-subtest coupling entirely.
+	//
+	// Outputs, each with a distinct script -- two outputs sharing one script make
+	// the wallet sign for the wrong prevout amount:
 	//
 	//	[0] receiver account, dust
 	//	[1] sender account, dust, carrying the sender's asset
-	//	[2] funder change, re-points funderFunding
-	funderFunding := findAccountInput(t, ctx, funder, indexerSvc, *funderAccount)
-
+	//	[2] funder change, unused
 	fundAccounts := func(t *testing.T, packet *asset.Packet) *wire.MsgTx {
 		t.Helper()
-		change := funderFunding.Amount - 2*dust
+
+		funder, funderWallet, funderPubKey, grpcFunder := setupArkSDKwithPublicKey(t)
+		t.Cleanup(func() { grpcFunder.Close() })
+		_ = fundAndSettleAlice(t, ctx, funder, 100_000)
+
+		funderAccount := defaultVtxoScript(funderPubKey, server, exitDelay)
+		funderAccountPk := p2trScriptForVtxoScript(t, *funderAccount)
+		funding := findAccountInput(t, ctx, funder, indexerSvc, *funderAccount)
+
+		change := funding.Amount - 2*dust
 		require.Positive(t, change)
 
 		tx, cps, err := offchain.BuildTxs(
-			[]offchain.VtxoInput{funderFunding},
+			[]offchain.VtxoInput{funding},
 			[]*wire.TxOut{
 				{Value: dust, PkScript: receiverAccountPk},
 				{Value: dust, PkScript: senderAccountPk},
@@ -254,11 +251,8 @@ func TestDustCovenant(t *testing.T) {
 		}
 
 		submitWithArkd(t, ctx, tx, cps, funderWallet, grpcFunder)
-		awaitSpendable(t, tx.UnsignedTx, 0, 1, 2)
+		awaitSpendable(t, tx.UnsignedTx, 0, 1)
 
-		funderFunding = vtxoInputFromScriptOutput(
-			t, tx.UnsignedTx, 2, *funderAccount, onlyForfeitScript(t, *funderAccount),
-		)
 		return tx.UnsignedTx
 	}
 

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
 	"github.com/arkade-os/arkd/pkg/ark-lib/offchain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/arkade-os/arkd/pkg/client-lib/indexer"
+	"github.com/arkade-os/arkd/pkg/client-lib/types"
 	"github.com/arkade-os/emulator/pkg/arkade"
 	"github.com/arkade-os/emulator/test/covenant"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -190,17 +192,32 @@ func TestDustCovenant(t *testing.T) {
 
 	// arkd registers a submitted transaction's outputs asynchronously, so
 	// spending one immediately can lose the race and fail with VTXO_NOT_FOUND.
-	// Polling the indexer for the transaction is used rather than the
-	// subscription helper: a subscription opened per funding transaction, over
-	// scripts an earlier subscription had already registered and removed, did not
-	// deliver its events (got 0/3) even though the transaction was accepted.
-	awaitIndexed := func(t *testing.T, tx *wire.MsgTx) {
+	//
+	// Waiting on the outpoints specifically, rather than on the transaction:
+	// GetVirtualTxs returns the transaction before its outputs are spendable, so
+	// waiting on that still raced. The subscription helper was not used either --
+	// a subscription opened per funding transaction, over scripts an earlier
+	// subscription had already registered and removed on cleanup, never delivered
+	// its events (got 0/3) even though the transaction was accepted.
+	awaitSpendable := func(t *testing.T, tx *wire.MsgTx, vouts ...uint32) {
 		t.Helper()
 		txid := tx.TxID()
+		outpoints := make([]types.Outpoint, 0, len(vouts))
+		for _, vout := range vouts {
+			outpoints = append(outpoints, types.Outpoint{Txid: txid, VOut: vout})
+		}
 		require.Eventually(t, func() bool {
-			res, err := indexerSvc.GetVirtualTxs(ctx, []string{txid})
-			return err == nil && len(res.Txs) == 1
-		}, 30*time.Second, 250*time.Millisecond, "tx %s never indexed", txid)
+			res, err := indexerSvc.GetVtxos(ctx, indexer.WithOutpoints(outpoints))
+			if err != nil || res == nil || len(res.Vtxos) != len(outpoints) {
+				return false
+			}
+			for _, v := range res.Vtxos {
+				if v.Spent {
+					return false
+				}
+			}
+			return true
+		}, 30*time.Second, 250*time.Millisecond, "vtxos of %s not spendable", txid)
 	}
 
 	funderAccount := defaultVtxoScript(funderPubKey, server, exitDelay)
@@ -237,7 +254,7 @@ func TestDustCovenant(t *testing.T) {
 		}
 
 		submitWithArkd(t, ctx, tx, cps, funderWallet, grpcFunder)
-		awaitIndexed(t, tx.UnsignedTx)
+		awaitSpendable(t, tx.UnsignedTx, 0, 1, 2)
 
 		funderFunding = vtxoInputFromScriptOutput(
 			t, tx.UnsignedTx, 2, *funderAccount, onlyForfeitScript(t, *funderAccount),
@@ -288,7 +305,7 @@ func TestDustCovenant(t *testing.T) {
 		}
 
 		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
-		awaitIndexed(t, tx.UnsignedTx)
+		awaitSpendable(t, tx.UnsignedTx, 0)
 
 		return tx.UnsignedTx
 	}

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
 	"testing"
 
@@ -10,215 +9,23 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/offchain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
 	"github.com/arkade-os/emulator/pkg/arkade"
+	"github.com/arkade-os/emulator/test/covenant"
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
-	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
+
+// The covenant logic itself is proven without a stack in test/covenant. This
+// file checks the parts only a live arkd and emulator can: that the emulator
+// signs a covenant-satisfying spend, that arkd accepts the resulting
+// transaction, and that the bitcoin accounting holds end to end.
 
 // ARKD_VTXO_MIN_AMOUNT=1 in docker-compose.regtest.yml. Not exposed by GetInfo.
 const dustCovenantVtxoMinAmount = int64(1)
 
 // Genesis-era timestamp: always already satisfied, as in htlc_test.go.
 const dustCovenantLocktime = arklib.AbsoluteLocktime(500_000_000)
-
-const (
-	leafRecycle = iota
-	leafPurchase
-	leafRefundSender
-	leafRecovery
-)
-
-type dustCovenantParams struct {
-	receiverKey *btcec.PublicKey
-	senderKey   *btcec.PublicKey
-	operatorKey *btcec.PublicKey
-	dust        int64
-	topup       int64
-	assetID     *asset.AssetId
-	locktime    arklib.AbsoluteLocktime
-}
-
-// refundTopup is what the operator recovers on the refund leaves. It falls below
-// topup only when the operator funded the whole dust unit, where one
-// vtxoMinAmount must stay behind to host the sender's returned asset.
-func (p dustCovenantParams) refundTopup(vtxoMinAmount int64) int64 {
-	if capped := p.dust - vtxoMinAmount; p.topup > capped {
-		return capped
-	}
-	return p.topup
-}
-
-// pinOutput binds an output to a key. pushScriptPubKey reports a witness program
-// as (program, version) but anything else as (sha256(script), -1), so a
-// below-dust output must be pinned in its sub-dust OP_RETURN form.
-func pinOutput(
-	t *testing.T, b *txscript.ScriptBuilder, vout int64, key *btcec.PublicKey, value, dust int64,
-) {
-	t.Helper()
-	b.AddInt64(vout).AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY)
-	if value >= dust {
-		b.AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
-			AddData(schnorr.SerializePubKey(key)).AddOp(arkade.OP_EQUALVERIFY)
-		return
-	}
-	h := sha256.Sum256(subDustPkScript(t, key))
-	b.AddInt64(-1).AddOp(arkade.OP_EQUALVERIFY).
-		AddData(h[:]).AddOp(arkade.OP_EQUALVERIFY)
-}
-
-func subDustPkScript(t *testing.T, key *btcec.PublicKey) []byte {
-	t.Helper()
-	s, err := script.SubDustScript(key)
-	require.NoError(t, err)
-	return s
-}
-
-// payoutPkScript is the scriptPubKey a covenant-pinned payout must actually use:
-// P2TR at or above dust, sub-dust OP_RETURN below it. It must agree with
-// pinOutput or the covenant rejects its own intended spend.
-func payoutPkScript(t *testing.T, key *btcec.PublicKey, value, dust int64) []byte {
-	t.Helper()
-	if value >= dust {
-		s, err := script.P2TRScript(key)
-		require.NoError(t, err)
-		return s
-	}
-	return subDustPkScript(t, key)
-}
-
-// appendAssetLookup leaves the asset amount on the stack, dropping the found
-// flag: a miss pushes (0, 0), which is exactly "holds none of this asset".
-// id.Txid must be internal byte order, never the reversed display hex.
-func appendAssetLookup(b *txscript.ScriptBuilder, idx int64, id *asset.AssetId, output bool) {
-	op := byte(arkade.OP_INSPECTINASSETLOOKUP)
-	if output {
-		op = byte(arkade.OP_INSPECTOUTASSETLOOKUP)
-	}
-	b.AddInt64(idx).AddData(id.Txid[:]).AddInt64(int64(id.Index)).
-		AddOp(op).AddOp(arkade.OP_DROP)
-}
-
-func finishCovenant(t *testing.T, b *txscript.ScriptBuilder, hasAsset bool) []byte {
-	t.Helper()
-	if !hasAsset {
-		b.AddOp(arkade.OP_1)
-	}
-	s, err := b.Script()
-	require.NoError(t, err)
-	return s
-}
-
-// buildRecycleCovenant gates the receiver merging the covenant into an account
-// they already own, repaying the operator's advance in sats.
-//
-//	in[0] covenant, in[1] receiver account
-//	out[0] operator repaid topup, out[1] receiver's merged account
-//
-// Output value is enforced as a sum over both inputs rather than a constant, so
-// the receiver's prior balance is irrelevant.
-func buildRecycleCovenant(t *testing.T, p dustCovenantParams) []byte {
-	t.Helper()
-	b := txscript.NewScriptBuilder().
-		AddOp(arkade.OP_PUSHCURRENTINPUTINDEX).AddInt64(0).AddOp(arkade.OP_EQUALVERIFY).
-		AddOp(arkade.OP_INSPECTNUMINPUTS).AddInt64(2).AddOp(arkade.OP_EQUALVERIFY).
-		AddInt64(1).AddOp(arkade.OP_INSPECTINPUTSCRIPTPUBKEY).
-		AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
-		AddData(schnorr.SerializePubKey(p.receiverKey)).AddOp(arkade.OP_EQUALVERIFY).
-		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
-		AddInt64(p.topup).AddOp(arkade.OP_EQUALVERIFY)
-
-	pinOutput(t, b, 0, p.operatorKey, p.topup, p.dust)
-
-	b.AddInt64(1).AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY).
-		AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
-		AddData(schnorr.SerializePubKey(p.receiverKey)).AddOp(arkade.OP_EQUALVERIFY).
-		AddInt64(1).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
-		AddInt64(0).AddOp(arkade.OP_INSPECTINPUTVALUE).
-		AddInt64(1).AddOp(arkade.OP_INSPECTINPUTVALUE).AddOp(arkade.OP_ADD).
-		AddInt64(p.topup).AddOp(arkade.OP_SUB).
-		AddOp(arkade.OP_EQUALVERIFY)
-
-	if p.assetID != nil {
-		appendAssetLookup(b, 1, p.assetID, true)
-		appendAssetLookup(b, 0, p.assetID, false)
-		appendAssetLookup(b, 1, p.assetID, false)
-		b.AddOp(arkade.OP_ADD).AddOp(arkade.OP_EQUAL)
-	}
-	return finishCovenant(t, b, p.assetID != nil)
-}
-
-// buildPurchaseCovenant pays the whole covenant to the receiver. The operator
-// recovers nothing here, having been compensated at lockup.
-func buildPurchaseCovenant(t *testing.T, p dustCovenantParams) []byte {
-	t.Helper()
-	b := txscript.NewScriptBuilder().
-		AddOp(arkade.OP_PUSHCURRENTINPUTINDEX).AddInt64(0).AddOp(arkade.OP_EQUALVERIFY).
-		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY).
-		AddOp(arkade.OP_1).AddOp(arkade.OP_EQUALVERIFY).
-		AddData(schnorr.SerializePubKey(p.receiverKey)).AddOp(arkade.OP_EQUALVERIFY).
-		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
-		AddInt64(0).AddOp(arkade.OP_INSPECTINPUTVALUE).AddOp(arkade.OP_EQUALVERIFY)
-
-	if p.assetID != nil {
-		appendAssetLookup(b, 0, p.assetID, true)
-		appendAssetLookup(b, 0, p.assetID, false)
-		b.AddOp(arkade.OP_EQUAL)
-	}
-	return finishCovenant(t, b, p.assetID != nil)
-}
-
-// buildRefundCovenant returns the payload to the sender and repays the operator.
-// Shared by the sender-signed refund leaf and the timelocked recovery leaf; the
-// sender's returned payload is a sub-dust receipt, which is acceptable because
-// the sender demonstrably owns a funded account and can merge it later.
-func buildRefundCovenant(t *testing.T, p dustCovenantParams, vtxoMinAmount int64) []byte {
-	t.Helper()
-	topup := p.refundTopup(vtxoMinAmount)
-	b := txscript.NewScriptBuilder().
-		AddOp(arkade.OP_PUSHCURRENTINPUTINDEX).AddInt64(0).AddOp(arkade.OP_EQUALVERIFY).
-		AddInt64(0).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
-		AddInt64(topup).AddOp(arkade.OP_EQUALVERIFY)
-
-	pinOutput(t, b, 0, p.operatorKey, topup, p.dust)
-
-	b.AddInt64(1).AddOp(arkade.OP_INSPECTOUTPUTVALUE).
-		AddInt64(p.dust - topup).AddOp(arkade.OP_EQUALVERIFY)
-
-	pinOutput(t, b, 1, p.senderKey, p.dust-topup, p.dust)
-
-	if p.assetID != nil {
-		appendAssetLookup(b, 1, p.assetID, true)
-		appendAssetLookup(b, 0, p.assetID, false)
-		b.AddOp(arkade.OP_EQUAL)
-	}
-	return finishCovenant(t, b, p.assetID != nil)
-}
-
-func buildDustCovenantVtxoScript(
-	server, emulator, sender *btcec.PublicKey,
-	p dustCovenantParams,
-	recycle, purchase, refund []byte,
-) script.TapscriptsVtxoScript {
-	tweak := func(s []byte) *btcec.PublicKey {
-		return arkade.ComputeArkadeScriptPublicKey(emulator, arkade.ArkadeScriptHash(s))
-	}
-	return script.TapscriptsVtxoScript{
-		Closures: []script.Closure{
-			&script.MultisigClosure{PubKeys: []*btcec.PublicKey{server, tweak(recycle)}},
-			&script.MultisigClosure{PubKeys: []*btcec.PublicKey{server, tweak(purchase)}},
-			&script.MultisigClosure{PubKeys: []*btcec.PublicKey{server, sender, tweak(refund)}},
-			&script.CLTVMultisigClosure{
-				MultisigClosure: script.MultisigClosure{
-					PubKeys: []*btcec.PublicKey{server, tweak(refund)},
-				},
-				Locktime: p.locktime,
-			},
-		},
-	}
-}
 
 // onlyForfeitScript requires exactly one forfeit closure; this taptree has four.
 func tapscriptAt(t *testing.T, vtxoScript script.TapscriptsVtxoScript, i int) []byte {
@@ -228,41 +35,42 @@ func tapscriptAt(t *testing.T, vtxoScript script.TapscriptsVtxoScript, i int) []
 	return s
 }
 
-type dustCovenantContract struct {
-	params   dustCovenantParams
-	recycle  []byte
-	purchase []byte
-	refund   []byte
+type dustContract struct {
+	params   covenant.Params
+	scripts  covenant.Scripts
 	vtxo     script.TapscriptsVtxoScript
 	pkScript []byte
 }
 
-func newDustCovenantContract(
-	t *testing.T, server, emulator, sender *btcec.PublicKey, p dustCovenantParams,
-) dustCovenantContract {
+func newDustContract(
+	t *testing.T, server, emulator, sender *btcec.PublicKey, p covenant.Params,
+) dustContract {
 	t.Helper()
-	recycle := buildRecycleCovenant(t, p)
-	purchase := buildPurchaseCovenant(t, p)
-	refund := buildRefundCovenant(t, p, dustCovenantVtxoMinAmount)
-	vtxo := buildDustCovenantVtxoScript(server, emulator, sender, p, recycle, purchase, refund)
-	return dustCovenantContract{
+	scripts, err := covenant.Build(p, dustCovenantVtxoMinAmount)
+	require.NoError(t, err)
+	vtxo := covenant.VtxoScript(server, emulator, sender, p, scripts)
+	return dustContract{
 		params:   p,
-		recycle:  recycle,
-		purchase: purchase,
-		refund:   refund,
+		scripts:  scripts,
 		vtxo:     vtxo,
 		pkScript: p2trScriptForVtxoScript(t, vtxo),
 	}
 }
 
-func (c dustCovenantContract) input(t *testing.T, prevTx *wire.MsgTx, leaf int) offchain.VtxoInput {
+func (c dustContract) input(t *testing.T, prevTx *wire.MsgTx, leaf int) offchain.VtxoInput {
 	t.Helper()
 	return vtxoInputFromScriptOutput(t, prevTx, 0, c.vtxo, tapscriptAt(t, c.vtxo, leaf))
 }
 
-// issuancePacket mints a fresh asset, splitting it across the given outputs.
-// Outputs with a zero amount are omitted so the recipient genuinely holds no
-// entry for the asset, which is what exercises the lookup miss path.
+func (c dustContract) payout(t *testing.T, key *btcec.PublicKey, value int64) []byte {
+	t.Helper()
+	s, err := covenant.PayoutPkScript(key, value, c.params.Dust)
+	require.NoError(t, err)
+	return s
+}
+
+// issuancePacket mints a fresh asset across the given outputs. Zero amounts are
+// omitted, so a recipient genuinely holds no entry for the asset.
 func issuancePacket(t *testing.T, amounts map[uint16]uint64) asset.Packet {
 	t.Helper()
 	outs := make([]asset.AssetOutput, 0, len(amounts))
@@ -297,27 +105,6 @@ func mergePacket(t *testing.T, id asset.AssetId, covenantUnits, accountUnits uin
 	require.NoError(t, err)
 	grp, err := asset.NewAssetGroup(
 		&id, nil, inputs, []asset.AssetOutput{*out}, []asset.Metadata{},
-	)
-	require.NoError(t, err)
-	pkt, err := asset.NewPacket([]asset.AssetGroup{*grp})
-	require.NoError(t, err)
-	return pkt
-}
-
-// shortedPacket balances the group but diverts one unit away from the receiver,
-// so the covenant's sum clause sees out[1] one short of in[0] + in[1].
-func shortedPacket(t *testing.T, id asset.AssetId, units uint64) asset.Packet {
-	t.Helper()
-	require.Greater(t, units, uint64(1))
-	in, err := asset.NewAssetInput(0, units)
-	require.NoError(t, err)
-	diverted, err := asset.NewAssetOutput(0, 1)
-	require.NoError(t, err)
-	out, err := asset.NewAssetOutput(1, units-1)
-	require.NoError(t, err)
-	grp, err := asset.NewAssetGroup(
-		&id, nil, []asset.AssetInput{*in},
-		[]asset.AssetOutput{*diverted, *out}, []asset.Metadata{},
 	)
 	require.NoError(t, err)
 	pkt, err := asset.NewPacket([]asset.AssetGroup{*grp})
@@ -369,22 +156,24 @@ func TestDustCovenant(t *testing.T) {
 	operatorKey, _, err := operatorAccount.TapTree()
 	require.NoError(t, err)
 
-	baseParams := func() dustCovenantParams {
-		return dustCovenantParams{
-			receiverKey: receiverKey,
-			senderKey:   senderKey,
-			operatorKey: operatorKey,
-			dust:        dust,
-			topup:       dust,
-			locktime:    dustCovenantLocktime,
+	baseParams := func() covenant.Params {
+		return covenant.Params{
+			ReceiverKey: receiverKey,
+			SenderKey:   senderKey,
+			OperatorKey: operatorKey,
+			Dust:        dust,
+			Topup:       dust,
+			Locktime:    dustCovenantLocktime,
 		}
 	}
 
-	// mint issues a fresh asset into the given outputs and returns the funding
-	// transaction plus its canonical AssetID. Issuance must happen in its own
-	// transaction: the covenant pins the AssetID, which for an issuance derives
-	// from that transaction's own txid.
-	mint := func(t *testing.T, outs []*wire.TxOut, amounts map[uint16]uint64) (*wire.MsgTx, asset.AssetId) {
+	// mint issues a fresh asset into the given outputs. Issuance must happen in
+	// its own transaction: the covenant pins the AssetID, which for an issuance
+	// derives from that transaction's own txid, so issuing inside the lockup
+	// would make the address depend on a txid that depends on the address.
+	mint := func(
+		t *testing.T, outs []*wire.TxOut, amounts map[uint16]uint64,
+	) (*wire.MsgTx, asset.AssetId) {
 		t.Helper()
 		tx, cps := buildWalletFundedTx(
 			t, ctx, sender, indexerSvc, senderPubKey, server, exitDelay,
@@ -396,9 +185,8 @@ func TestDustCovenant(t *testing.T) {
 		return tx.UnsignedTx, asset.AssetId{Txid: [asset.TX_HASH_SIZE]byte(h), Index: 0}
 	}
 
-	// lockup spends the sender's asset-bearing account into the covenant.
 	lockup := func(
-		t *testing.T, mintTx *wire.MsgTx, mintVout uint32, c dustCovenantContract, units uint64,
+		t *testing.T, mintTx *wire.MsgTx, mintVout uint32, c dustContract, units uint64,
 	) *wire.MsgTx {
 		t.Helper()
 		in := vtxoInputFromScriptOutput(
@@ -406,11 +194,11 @@ func TestDustCovenant(t *testing.T) {
 		)
 		tx, cps, err := offchain.BuildTxs(
 			[]offchain.VtxoInput{in},
-			[]*wire.TxOut{{Value: c.params.dust, PkScript: c.pkScript}},
+			[]*wire.TxOut{{Value: c.params.Dust, PkScript: c.pkScript}},
 			checkpointScript,
 		)
 		require.NoError(t, err)
-		if c.params.assetID != nil {
+		if c.params.AssetID != nil {
 			addAssetPacketToTx(t, tx, createTransferAssetPacket(
 				t, mintTx.TxHash(), 0, uint16(mintVout), 0, units,
 			))
@@ -427,7 +215,7 @@ func TestDustCovenant(t *testing.T) {
 		return err
 	}
 
-	t.Run("purchase/valid", func(t *testing.T) {
+	t.Run("purchase", func(t *testing.T) {
 		const units = uint64(100)
 
 		mintTx, assetID := mint(t,
@@ -436,13 +224,13 @@ func TestDustCovenant(t *testing.T) {
 		)
 
 		p := baseParams()
-		p.assetID = &assetID
-		c := newDustCovenantContract(t, server, emulatorPubKey, senderPubKey, p)
+		p.AssetID = &assetID
+		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
 		lockTx := lockup(t, mintTx, 0, c, units)
 
 		claimTx, claimCps, err := offchain.BuildTxs(
-			[]offchain.VtxoInput{c.input(t, lockTx, leafPurchase)},
+			[]offchain.VtxoInput{c.input(t, lockTx, covenant.LeafPurchase)},
 			[]*wire.TxOut{{Value: dust, PkScript: receiverAccountPk}},
 			checkpointScript,
 		)
@@ -450,15 +238,16 @@ func TestDustCovenant(t *testing.T) {
 		addAssetPacketToTx(t, claimTx, createTransferAssetPacket(
 			t, lockTx.TxHash(), 0, 0, 0, units,
 		))
-		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{{Vin: 0, Script: c.purchase}})
+		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{
+			{Vin: 0, Script: c.scripts.Purchase},
+		})
 
 		require.NoError(t, executeArkadeScripts(t, claimTx, claimCps, emulatorPubKey))
 		require.NoError(t, submitToEmulator(t, claimTx, claimCps))
 	})
 
 	// recycleCase drives the merge path for a receiver holding priorUnits of the
-	// same asset. priorUnits == 0 exercises the (0, 0) miss return of
-	// OP_INSPECTINASSETLOOKUP, which is what lets one script serve both cases.
+	// same asset. priorUnits == 0 exercises the lookup miss path.
 	recycleCase := func(t *testing.T, priorUnits uint64) {
 		t.Helper()
 		const sent = uint64(1)
@@ -472,34 +261,37 @@ func TestDustCovenant(t *testing.T) {
 		)
 
 		p := baseParams()
-		p.assetID = &assetID
-		c := newDustCovenantContract(t, server, emulatorPubKey, senderPubKey, p)
+		p.AssetID = &assetID
+		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
 		lockTx := lockup(t, mintTx, 0, c, sent)
 
-		covenantIn := c.input(t, lockTx, leafRecycle)
+		covenantIn := c.input(t, lockTx, covenant.LeafRecycle)
 		accountIn := vtxoInputFromScriptOutput(
 			t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
 		)
 
-		merged := covenantIn.Amount + accountIn.Amount - p.topup
+		merged := covenantIn.Amount + accountIn.Amount - p.Topup
 		claimTx, claimCps, err := offchain.BuildTxs(
 			[]offchain.VtxoInput{covenantIn, accountIn},
 			[]*wire.TxOut{
-				{Value: p.topup, PkScript: payoutPkScript(t, operatorKey, p.topup, dust)},
+				{Value: p.Topup, PkScript: c.payout(t, operatorKey, p.Topup)},
 				{Value: merged, PkScript: receiverAccountPk},
 			},
 			checkpointScript,
 		)
 		require.NoError(t, err)
 		addAssetPacketToTx(t, claimTx, mergePacket(t, assetID, sent, priorUnits))
-		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{{Vin: 0, Script: c.recycle}})
+		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{
+			{Vin: 0, Script: c.scripts.Recycle},
+		})
 
 		require.NoError(t, executeArkadeScripts(t, claimTx, claimCps, emulatorPubKey))
+		require.NoError(t, submitToEmulator(t, claimTx, claimCps))
 
 		require.Equal(t, accountIn.Amount, claimTx.UnsignedTx.TxOut[1].Value,
 			"receiver's bitcoin balance must be unchanged")
-		require.Equal(t, p.topup, claimTx.UnsignedTx.TxOut[0].Value,
+		require.Equal(t, p.Topup, claimTx.UnsignedTx.TxOut[0].Value,
 			"operator must recover its advance in full")
 	}
 
@@ -511,11 +303,7 @@ func TestDustCovenant(t *testing.T) {
 		recycleCase(t, 0)
 	})
 
-	// refundCase drives the shared refund covenant. leafRefundSender additionally
-	// requires the sender's signature, which the tapscript closure enforces
-	// rather than the covenant, so both leaves assert the same script.
-	refundCase := func(t *testing.T, leaf int) {
-		t.Helper()
+	t.Run("recovery/after_locktime", func(t *testing.T) {
 		const units = uint64(7)
 
 		mintTx, assetID := mint(t,
@@ -524,38 +312,67 @@ func TestDustCovenant(t *testing.T) {
 		)
 
 		p := baseParams()
-		p.assetID = &assetID
-		c := newDustCovenantContract(t, server, emulatorPubKey, senderPubKey, p)
+		p.AssetID = &assetID
+		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
 		lockTx := lockup(t, mintTx, 0, c, units)
-		topup := p.refundTopup(dustCovenantVtxoMinAmount)
+		topup := p.RefundTopup(dustCovenantVtxoMinAmount)
 
 		refundTx, refundCps, err := offchain.BuildTxs(
-			[]offchain.VtxoInput{c.input(t, lockTx, leaf)},
+			[]offchain.VtxoInput{c.input(t, lockTx, covenant.LeafRecovery)},
 			[]*wire.TxOut{
-				{Value: topup, PkScript: payoutPkScript(t, operatorKey, topup, dust)},
-				{Value: dust - topup, PkScript: payoutPkScript(t, senderKey, dust-topup, dust)},
+				{Value: topup, PkScript: c.payout(t, operatorKey, topup)},
+				{Value: dust - topup, PkScript: c.payout(t, senderKey, dust-topup)},
 			},
 			checkpointScript,
 		)
 		require.NoError(t, err)
-		refundTx.UnsignedTx.LockTime = uint32(p.locktime)
+		refundTx.UnsignedTx.LockTime = uint32(p.Locktime)
 		addAssetPacketToTx(t, refundTx, createTransferAssetPacket(
 			t, lockTx.TxHash(), 0, 0, 1, units,
 		))
-		addEmulatorPacket(t, refundTx, []arkade.EmulatorEntry{{Vin: 0, Script: c.refund}})
+		addEmulatorPacket(t, refundTx, []arkade.EmulatorEntry{
+			{Vin: 0, Script: c.scripts.Refund},
+		})
 
 		require.NoError(t, executeArkadeScripts(t, refundTx, refundCps, emulatorPubKey))
-		require.Equal(t, dust-topup, refundTx.UnsignedTx.TxOut[1].Value,
-			"sender's returned payload must host the asset above vtxoMinAmount")
-	}
-
-	t.Run("refund/sender_signed", func(t *testing.T) {
-		refundCase(t, leafRefundSender)
+		require.NoError(t, submitToEmulator(t, refundTx, refundCps))
 	})
 
-	t.Run("recovery/after_locktime", func(t *testing.T) {
-		refundCase(t, leafRecovery)
+	// The covenant does not read the locktime; the CLTV closure does. Only a live
+	// emulator can reject this, which is why it has no counterpart in the
+	// stack-free covenant tests.
+	t.Run("recovery/rejected_before_locktime", func(t *testing.T) {
+		const units = uint64(7)
+
+		mintTx, assetID := mint(t,
+			[]*wire.TxOut{{Value: dust, PkScript: senderAccountPk}},
+			map[uint16]uint64{0: units},
+		)
+
+		p := baseParams()
+		p.AssetID = &assetID
+		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
+
+		lockTx := lockup(t, mintTx, 0, c, units)
+		topup := p.RefundTopup(dustCovenantVtxoMinAmount)
+
+		tx, cps, err := offchain.BuildTxs(
+			[]offchain.VtxoInput{c.input(t, lockTx, covenant.LeafRecovery)},
+			[]*wire.TxOut{
+				{Value: topup, PkScript: c.payout(t, operatorKey, topup)},
+				{Value: dust - topup, PkScript: c.payout(t, senderKey, dust-topup)},
+			},
+			checkpointScript,
+		)
+		require.NoError(t, err)
+		tx.UnsignedTx.LockTime = uint32(p.Locktime) - 1
+		addAssetPacketToTx(t, tx, createTransferAssetPacket(
+			t, lockTx.TxHash(), 0, 0, 1, units,
+		))
+		addEmulatorPacket(t, tx, []arkade.EmulatorEntry{{Vin: 0, Script: c.scripts.Refund}})
+
+		require.Error(t, submitToEmulator(t, tx, cps))
 	})
 
 	t.Run("bitcoin_variant/recycle_50_sats", func(t *testing.T) {
@@ -570,171 +387,36 @@ func TestDustCovenant(t *testing.T) {
 		)
 
 		p := baseParams()
-		p.topup = dust - payload
-		c := newDustCovenantContract(t, server, emulatorPubKey, senderPubKey, p)
+		p.Topup = dust - payload
+		c := newDustContract(t, server, emulatorPubKey, senderPubKey, p)
 
 		lockTx := lockup(t, mintTx, 0, c, 0)
 
-		covenantIn := c.input(t, lockTx, leafRecycle)
+		covenantIn := c.input(t, lockTx, covenant.LeafRecycle)
 		accountIn := vtxoInputFromScriptOutput(
 			t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
 		)
 
-		merged := covenantIn.Amount + accountIn.Amount - p.topup
+		merged := covenantIn.Amount + accountIn.Amount - p.Topup
 		claimTx, claimCps, err := offchain.BuildTxs(
 			[]offchain.VtxoInput{covenantIn, accountIn},
 			[]*wire.TxOut{
-				{Value: p.topup, PkScript: payoutPkScript(t, operatorKey, p.topup, dust)},
+				{Value: p.Topup, PkScript: c.payout(t, operatorKey, p.Topup)},
 				{Value: merged, PkScript: receiverAccountPk},
 			},
 			checkpointScript,
 		)
 		require.NoError(t, err)
-		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{{Vin: 0, Script: c.recycle}})
+		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{
+			{Vin: 0, Script: c.scripts.Recycle},
+		})
 
 		require.NoError(t, executeArkadeScripts(t, claimTx, claimCps, emulatorPubKey))
+		require.NoError(t, submitToEmulator(t, claimTx, claimCps))
 
 		require.Equal(t, payload, claimTx.UnsignedTx.TxOut[1].Value-accountIn.Amount,
 			"receiver must gain exactly the payload")
 		require.Equal(t, dust-payload, claimTx.UnsignedTx.TxOut[0].Value,
 			"operator must be made whole")
-	})
-
-	t.Run("reject", func(t *testing.T) {
-		const units = uint64(3)
-
-		mintTx, assetID := mint(t,
-			[]*wire.TxOut{
-				{Value: dust, PkScript: senderAccountPk},
-				{Value: dust, PkScript: receiverAccountPk},
-			},
-			map[uint16]uint64{0: units},
-		)
-
-		p := baseParams()
-		p.assetID = &assetID
-		c := newDustCovenantContract(t, server, emulatorPubKey, senderPubKey, p)
-
-		lockTx := lockup(t, mintTx, 0, c, units)
-
-		// buildRecycle produces a valid recycle spend, then applies a mutation.
-		// Each rejection case corrupts exactly one thing.
-		buildRecycle := func(
-			t *testing.T, mutate func(outs []*wire.TxOut, ins *[]offchain.VtxoInput),
-		) (*psbt.Packet, []*psbt.Packet) {
-			t.Helper()
-			covenantIn := c.input(t, lockTx, leafRecycle)
-			accountIn := vtxoInputFromScriptOutput(
-				t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
-			)
-			ins := []offchain.VtxoInput{covenantIn, accountIn}
-			outs := []*wire.TxOut{
-				{Value: p.topup, PkScript: payoutPkScript(t, operatorKey, p.topup, dust)},
-				{
-					Value:    covenantIn.Amount + accountIn.Amount - p.topup,
-					PkScript: receiverAccountPk,
-				},
-			}
-			mutate(outs, &ins)
-
-			tx, cps, err := offchain.BuildTxs(ins, outs, checkpointScript)
-			require.NoError(t, err)
-			addAssetPacketToTx(t, tx, mergePacket(t, assetID, units, 0))
-			addEmulatorPacket(t, tx, []arkade.EmulatorEntry{{Vin: 0, Script: c.recycle}})
-			return tx, cps
-		}
-
-		expectRejected := func(t *testing.T, ptx *psbt.Packet, cps []*psbt.Packet) {
-			t.Helper()
-			require.Error(t, executeArkadeScripts(t, ptx, cps, emulatorPubKey))
-			require.Error(t, submitToEmulator(t, ptx, cps))
-		}
-
-		t.Run("wrong_receiver", func(t *testing.T) {
-			tx, cps := buildRecycle(t, func(outs []*wire.TxOut, _ *[]offchain.VtxoInput) {
-				outs[1].PkScript = randomP2TRScript(t)
-			})
-			expectRejected(t, tx, cps)
-		})
-
-		t.Run("operator_underpaid", func(t *testing.T) {
-			tx, cps := buildRecycle(t, func(outs []*wire.TxOut, _ *[]offchain.VtxoInput) {
-				outs[0].Value--
-				outs[1].Value++
-			})
-			expectRejected(t, tx, cps)
-		})
-
-		t.Run("extra_input", func(t *testing.T) {
-			tx, cps := buildRecycle(t, func(_ []*wire.TxOut, ins *[]offchain.VtxoInput) {
-				extra := vtxoInputFromScriptOutput(
-					t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
-				)
-				*ins = append(*ins, extra)
-			})
-			expectRejected(t, tx, cps)
-		})
-
-		t.Run("wrong_account_at_input_one", func(t *testing.T) {
-			tx, cps := buildRecycle(t, func(_ []*wire.TxOut, ins *[]offchain.VtxoInput) {
-				(*ins)[1] = vtxoInputFromScriptOutput(
-					t, mintTx, 0, *senderAccount, onlyForfeitScript(t, *senderAccount),
-				)
-			})
-			expectRejected(t, tx, cps)
-		})
-
-		// Shorting the pinned asset is the substitution case the covenant can
-		// actually catch. Swapping in a foreign AssetID instead makes all three
-		// lookups miss, so the clause degenerates to 0 == 0 + 0 and passes; what
-		// rejects that spend is arkd's asset-balance validation, which sees the
-		// covenant's asset entering with no matching group. Substitution safety
-		// is a property of the covenant and arkd together, not the covenant alone.
-		t.Run("asset_amount_shorted", func(t *testing.T) {
-			covenantIn := c.input(t, lockTx, leafRecycle)
-			accountIn := vtxoInputFromScriptOutput(
-				t, mintTx, 1, *receiverAccount, onlyForfeitScript(t, *receiverAccount),
-			)
-			tx, cps, err := offchain.BuildTxs(
-				[]offchain.VtxoInput{covenantIn, accountIn},
-				[]*wire.TxOut{
-					{Value: p.topup, PkScript: payoutPkScript(t, operatorKey, p.topup, dust)},
-					{
-						Value:    covenantIn.Amount + accountIn.Amount - p.topup,
-						PkScript: receiverAccountPk,
-					},
-				},
-				checkpointScript,
-			)
-			require.NoError(t, err)
-			addAssetPacketToTx(t, tx, shortedPacket(t, assetID, units))
-			addEmulatorPacket(t, tx, []arkade.EmulatorEntry{{Vin: 0, Script: c.recycle}})
-			expectRejected(t, tx, cps)
-		})
-
-		t.Run("recovery_before_locktime", func(t *testing.T) {
-			topup := p.refundTopup(dustCovenantVtxoMinAmount)
-			tx, cps, err := offchain.BuildTxs(
-				[]offchain.VtxoInput{c.input(t, lockTx, leafRecovery)},
-				[]*wire.TxOut{
-					{Value: topup, PkScript: payoutPkScript(t, operatorKey, topup, dust)},
-					{
-						Value:    dust - topup,
-						PkScript: payoutPkScript(t, senderKey, dust-topup, dust),
-					},
-				},
-				checkpointScript,
-			)
-			require.NoError(t, err)
-			tx.UnsignedTx.LockTime = uint32(p.locktime) - 1
-			addAssetPacketToTx(t, tx, createTransferAssetPacket(
-				t, lockTx.TxHash(), 0, 0, 1, units,
-			))
-			addEmulatorPacket(t, tx, []arkade.EmulatorEntry{{Vin: 0, Script: c.refund}})
-
-			// The covenant itself does not read the locktime; the CLTV closure
-			// does. Only the live emulator can reject this.
-			require.Error(t, submitToEmulator(t, tx, cps))
-		})
 	})
 }

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
 	"github.com/arkade-os/arkd/pkg/ark-lib/offchain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/arkade-os/arkd/pkg/ark-lib/txutils"
 	"github.com/arkade-os/arkd/pkg/client-lib/indexer"
 	"github.com/arkade-os/arkd/pkg/client-lib/types"
 	"github.com/arkade-os/emulator/pkg/arkade"
@@ -99,6 +100,20 @@ func issuancePacket(t *testing.T, amounts map[uint16]uint64) asset.Packet {
 	pkt, err := asset.NewPacket([]asset.AssetGroup{*grp})
 	require.NoError(t, err)
 	return pkt
+}
+
+// setPrevArkTxs attaches each input's previous arkade transaction. This is not
+// automatic: executeArkadeScripts and the emulator skip inputs without the
+// field, so FetchVtxoPrevOutPkScript returns nil and OP_INSPECTINPUTSCRIPTPUBKEY
+// fails with "previous output not found". Only recycle needs it, being the only
+// covenant that inspects a second input -- purchase reads input values, which
+// resolve through FetchPrevOutput and the PSBT's witness UTXO instead.
+// See test/cross_input_script_validation_test.go:345-346.
+func setPrevArkTxs(t *testing.T, ptx *psbt.Packet, prevs ...*wire.MsgTx) {
+	t.Helper()
+	for i, prev := range prevs {
+		require.NoError(t, txutils.SetArkPsbtField(ptx, i, arkade.PrevArkTxField, *prev))
+	}
 }
 
 // mergePacket moves the covenant's units at vin 0, plus whatever the receiver's
@@ -387,6 +402,7 @@ func TestDustCovenant(t *testing.T) {
 		)
 		require.NoError(t, err)
 		addAssetPacketToTx(t, claimTx, mergePacket(t, assetID, sent, priorUnits))
+		setPrevArkTxs(t, claimTx, lockTx, mintTx)
 		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{
 			{Vin: 0, Script: c.scripts.Recycle},
 		})
@@ -506,6 +522,7 @@ func TestDustCovenant(t *testing.T) {
 			checkpointScript,
 		)
 		require.NoError(t, err)
+		setPrevArkTxs(t, claimTx, lockTx, fundTx)
 		addEmulatorPacket(t, claimTx, []arkade.EmulatorEntry{
 			{Vin: 0, Script: c.scripts.Recycle},
 		})

--- a/test/dust_covenant_test.go
+++ b/test/dust_covenant_test.go
@@ -196,7 +196,13 @@ func TestDustCovenant(t *testing.T) {
 		if packet != nil {
 			addAssetPacketToTx(t, tx, *packet)
 		}
+
+		// arkd registers the new VTXOs asynchronously; spending one before it is
+		// observable fails with VTXO_NOT_FOUND. The subscription must be opened
+		// before submitting, and after the outputs are final.
+		confirmed := watchForPreconfirmedVtxos(t, indexerSvc, tx, 0, 1, 2)
 		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
+		confirmed()
 
 		senderFunding = vtxoInputFromScriptOutput(
 			t, tx.UnsignedTx, 2, *senderAccount, onlyForfeitScript(t, *senderAccount),
@@ -245,7 +251,11 @@ func TestDustCovenant(t *testing.T) {
 				t, fundTx.TxHash(), 0, 0, 0, units,
 			))
 		}
+
+		confirmed := watchForPreconfirmedVtxos(t, indexerSvc, tx, 0)
 		submitWithArkd(t, ctx, tx, cps, senderWallet, grpcSender)
+		confirmed()
+
 		return tx.UnsignedTx
 	}
 


### PR DESCRIPTION
Adds the covenant scripts and tests for a dust-free transfer: a sender pays an
asset, or a sub-dust amount of bitcoin, without committing a dust unit of their
own. A service operator fronts the dust and an arkade covenant guarantees its
repayment.

Tests only — no changes to the emulator itself.

## Why

Arkade already supports sub-dust outputs (`OP_RETURN <xonly>`, value in
`[vtxoMinAmount, dust)`), and the SDK routes below-dust sends into them
automatically. Two things stop that from being the answer:

- On a default-configured service it is unavailable: `resolveMinAmounts` sets
  `vtxoMinAmount = dustAmount` when unset, making the sub-dust window empty.
- Where it is available, `OP_RETURN` is unspendable on-chain, so the receiver
  holds a VTXO they can never unilaterally exit. The SDK marks these `Swept`.

So the covenant's job is not "make sub-dust payments possible" — they already
are — but "let a receiver end up with a fully exitable VTXO without the sender
funding the dust."

## Shape

Four leaves over three covenant scripts. Leaves 3 and 4 share `refund` and
differ only in closure.

| # | Leaf | Closure | Covenant |
| --- | --- | --- | --- |
| 1 | `recycle` | `Multisig[server, ⊕recycle]` | receiver merges into an account they own, repaying the operator in sats |
| 2 | `purchase` | `Multisig[server, ⊕purchase]` | receiver keeps the whole covenant; operator was paid at lockup |
| 3 | `refundSender` | `Multisig[server, sender, ⊕refund]` | sender cancels, operator repaid |
| 4 | `recovery` | `CLTV(L) + Multisig[server, ⊕refund]` | **sender-permissionless** after timeout — see note |

Leaf 4 needs no *party* signature once `L` passes, but the **server signature is
still required**, as on every leaf. It is sender-permissionless, not
permissionless: the operator's exposure is bounded by `L` *and* by server
liveness, which matters when sizing `L`. An earlier revision of this description
said "permissionless after timeout" — that was wrong.

`recycle` enforces output value and asset amount as a **sum over introspected
inputs** rather than as constants, so the receiver's prior balance is irrelevant.
That is the improvement over the `TestAssetAccountCovenant` prototype, whose
header records that it must assume the receiver holds zero. Both cases are
covered end to end.

Deliberately does not use `OP_TUNNEL`. It exists on master but not in the
deployed `v0.0.7` emulator, so an `OP_TUNNEL` covenant would compile and then
fail against the emulator actually running.

## Testing, in two layers

**`test/covenant` — no stack required.** The builders live in an importable
package rather than a `_test` file, so they can be driven straight through
`arkade.NewEngine` with synthetic transactions. **38 subtests**, about a second.
Picked up by `make test`, so it runs in the `unit` job.

**`test/dust_covenant_test.go` — live stack.** Covers what the above cannot:
that the emulator signs, that arkd accepts, that the CLTV closure rejects a
premature recovery (the covenant does not read locktime; the closure does), and
that the bitcoin accounting holds end to end. **All 7 subtests pass**, covering
every leaf including `refundSender`.

## Defects found by executing rather than reading

**`OP_INSPECTINPUTSCRIPTPUBKEY` reads `FetchVtxoPrevOutPkScript`**
(`pkg/arkade/opcode.go:2128`), not `FetchPrevOutput` (`:2070`). A fetcher stub
implementing only the latter aborts every input-inspecting covenant at that
instruction — so every rejection test passed without ever reaching the condition
it claimed to test. Rejection tests now assert the script error *code*. The same
distinction reappeared in the integration layer: `PrevArkTxField` must be set per
input or that opcode cannot resolve the input it inspects.

**Dropping the asset lookup's found-flag made the asset constraint optional.** A
miss returns `(0, 0)` — amount and flag. Dropping the flag everywhere meant a
wrong `AssetID` missed on all three reads, the sum degenerated to `0 == 0 + 0`,
and the covenant passed with the asset clause silently unenforced. The flag is
now `OP_VERIFY`'d wherever the asset must exist, and dropped only for the
receiver's prior balance, which may legitimately be zero.

This inverts the severity of the byte-order trap the HTLC v3 design records.
There, reversing `asset_txid` yields a silently *unspendable* contract: loud, and
safe. Under a dropped flag the same slip yielded a vacuously *true* asset clause:
quiet, and unsafe. It also caught a real bug in the integration test on its first
run, which had pinned the lockup txid instead of the issuance txid.

Every flag-dependent rejection test is mutation-checked: disabling the
`OP_VERIFY` makes all six accept spends they must reject. Removing the
`numInputs` guard likewise makes `reject_extra_input` fail.

## Known gap: forfeit — tracked in #151

`ForfeitClosures()` returns every `Multisig`/`CLTV` closure in a taptree, so for
this four-leaf tree `forfeitClosures[0]` resolves to `Multisig[server, ⊕recycle]`
and a forfeit built against it cannot satisfy the recycle covenant.

This affects none of the four spending paths, which is why every test here
passes without touching it. It bites at batch settlement: if the batch holding
the lockup output sweeps before the VTXO is spent, the forfeit path is
unavailable. That makes `L` and the operator's recovery scheduling load-bearing
for **fund safety**, not merely for recovering the operator's advance.

Not fixable in a tests-only PR. Tracked in **#151** with three candidate
resolutions and the decision explicitly deferred to a maintainer.

## Notes for whoever writes the next integration test

Several constraints here are not obvious and cost several iterations:

- **Never put two outputs with the same script in one transaction.** Sighash
  commits to the prevout amount and the wallet resolves inputs by script, taking
  the first match, so the second output signs for the wrong amount. This surfaces
  as an invalid checkpoint signature, and separately breaks `findTaprootOutput`.
- **`submitWithArkd` bypasses the SDK's wallet**, so `ListVtxos` never sees the
  spend and `buildWalletFundedTx` will hand back an already-spent input. Call it
  once, or thread inputs explicitly.
- **Wait on the outpoints, not the transaction.** `GetVirtualTxs` returns a
  transaction before arkd has registered its outputs as spendable.
- **Issue to a single output.** A two-output *issuance* made the funding
  transaction fail to finalize with an invalid checkpoint signature; multi-output
  *transfers* are fine, and the prototype's routing packet splits across three.
  The lockup does the split here instead.
- **Set `PrevArkTxField` per input.** It is not automatic, and without it
  `OP_INSPECTINPUTSCRIPTPUBKEY` cannot resolve the input it inspects.

## Worth a reviewer's opinion

- **Package location.** `test/covenant` is a non-test package under a test
  directory, which is unusual. It is there so the covenants can be executed
  without the `nigiri`-dependent `TestMain` in package `test`, and so an operator
  implementation could consume them. `pkg/covenant` would imply a supported
  public API that this is not yet. Happy to move it.
- **Leaves 3 and 4 share one script.** That costs the operator one
  `vtxoMinAmount` on a sender-signed refund of a pure-asset payment, since the
  shared script must pay the sender a standalone sub-dust output. Splitting them
  would let leaf 3 merge into the sender's account instead. Traded for one fewer
  script to audit.
- **`recycle` pins `numInputs == 2`,** so the receiver must merge from exactly one
  account VTXO. Over-constrained on purpose for a first version.
- **Substitution safety is a property of the covenant *and* arkd together** for
  one case: a foreign `AssetID` is now rejected by the covenant, but the covenant
  cannot detect an asset silently vanishing — arkd's balance validation does.
- **`Params.Validate` requires the three keys distinct.** Receiver equal to
  operator would let the operator satisfy `recycle` while paying the top-up
  repayment to itself, collecting both sides, with no signature check to notice.

Design doc is not committed, per repo convention on `docs/superpowers/`. Happy to
paste it into an issue if useful.
